### PR TITLE
Вставляет шаблон для заготовки

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -102,6 +102,11 @@ module.exports = function(config) {
     return value.toISOString()
   })
 
+  // Фильтрует теги
+  config.addFilter("filterTagListStubOnly", tags => {
+    return (tags || []).filter(tag => ["doka", "article"].indexOf(tag) === -1);
+  })
+
   config.addTransform('htmlmin', (content, outputPath) => {
     if (outputPath) {
       let isHtml = outputPath.endsWith('.html')

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -103,9 +103,9 @@ module.exports = function(config) {
   })
 
   // Фильтрует теги
-  config.addFilter("filterTagListStubOnly", tags => {
-    return (tags || []).filter(tag => ["doka", "article"].indexOf(tag) === -1);
-  })
+  config.addFilter("hasTag", (tags, tag) => {
+    return tags.includes(tag);
+  });
 
   config.addTransform('htmlmin', (content, outputPath) => {
     if (outputPath) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -108,7 +108,7 @@ module.exports = function(config) {
   
   // Фильтрует теги
   config.addFilter("hasTag", (tags, tag) => {
-    return tags.includes(tag);
+    return (tags || []).includes(tag);
   });
 
   config.addTransform('htmlmin', (content, outputPath) => {

--- a/src/includes/stub.njk
+++ b/src/includes/stub.njk
@@ -1,3 +1,1 @@
-<section>
-  <p>Это незавершённая статья про {{ title }}. Вы можете помочь её закончить! Почитайте <a href="https://github.com/doka-guide/content/blob/main/docs/contributing.md" target="_blank" rel="noopener noreferrer">о том, как контрибьютить в Доку</a>.</p>
-</section>
+<p>Это незавершённая статья. Вы можете помочь её закончить! Почитайте <a href="https://github.com/doka-guide/content/blob/main/docs/contributing.md" target="_blank">о том, как контрибьютить в Доку</a>.</p>

--- a/src/includes/stub.njk
+++ b/src/includes/stub.njk
@@ -1,0 +1,3 @@
+<section>
+  <p>Это незавершённая статья про {{ title }}. Вы можете помочь её закончить! Почитайте <a href="https://github.com/doka-guide/content/blob/main/docs/contributing.md" target="_blank" rel="noopener noreferrer">о том, как контрибьютить в Доку</a>.</p>
+</section>

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -29,6 +29,10 @@
 
           <p>{% lastModified page.date %}</p>
 
+          {% for tag in tags | filterTagListStubOnly %}
+            {% include "stub.njk" %}
+          {% endfor %}
+
           {{ content | safe }}
 
         </article>

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -29,9 +29,9 @@
 
           <p>{% lastModified page.date %}</p>
 
-          {% for tag in tags | filterTagListStubOnly %}
+          {% if tags | hasTag('placeholder') %}
             {% include "stub.njk" %}
-          {% endfor %}
+          {% endif %}
 
           {{ content | safe }}
 


### PR DESCRIPTION
У нас планируется ввести статьи-заготовки. В такой статье можно указать тег 

```
---
tags: 
    - placeholder
---
```

И появится соответствующая плашка. 

<img width="1275" alt="Снимок экрана 2021-06-21 в 12 24 20" src="https://user-images.githubusercontent.com/50330458/122743658-da539880-d28f-11eb-921d-c1cbfa6d32fa.png">


Можно попробовать на существующем контенте. 