### PR TITLE
Предотвращает падение сборки, если нет поля `updatedAt`

### DIFF
--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -42,7 +42,7 @@ module.exports = {
 
     updatedAt: function(data) {
       const { doc } = data
-      return new Date(doc.data.updatedAt)
+      return doc.data.updatedAt ? new Date(doc.data.updatedAt) : null
     }
   }
 }

--- a/src/views/doc.njk
+++ b/src/views/doc.njk
@@ -18,12 +18,14 @@
         Отредактировать на GitHub
       </a>
 
-      <p>
-        Отредактировано:
-        <time data-relative-time datetime="{{ updatedAt | isoDate }}">
-           {{ updatedAt | ruDate }}
-        </time>
-      </p>
+      {% if updatedAt %}
+        <p>
+          Отредактировано:
+          <time data-relative-time datetime="{{ updatedAt | isoDate }}">
+            {{ updatedAt | ruDate }}
+          </time>
+        </p>
+      {% endif %}
 
       {% if doc.data.tags | hasTag('placeholder') %}
         {% include "placeholder.njk" %}


### PR DESCRIPTION
Fallback-дата была убрана, но [иногда возникают случаи](https://github.com/doka-guide/content/issues/1177), что файл `index.11tydata.json` не создается. Поэтому вообще не выводим блок с датой, чтобы не было падения сборки.