### PR TITLE
Добавляет метрику

### DIFF
--- a/src/includes/analytics/metrika.njk
+++ b/src/includes/analytics/metrika.njk
@@ -7,9 +7,7 @@
    ym(83244811, "init", {
         clickmap:true,
         trackLinks:true,
-        accurateTrackBounce:true,
-        webvisor:true,
-        trackHash:true
+        accurateTrackBounce:true
    });
 </script>
 <noscript><div><img src="https://mc.yandex.ru/watch/83244811" style="position:absolute; left:-9999px;" alt="" /></div></noscript>

--- a/src/includes/analytics/metrika.njk
+++ b/src/includes/analytics/metrika.njk
@@ -1,0 +1,16 @@
+<!-- Yandex.Metrika counter -->
+<script type="text/javascript" >
+   (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+   m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+   (window, document, "script", "https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js", "ym");
+
+   ym(83244811, "init", {
+        clickmap:true,
+        trackLinks:true,
+        accurateTrackBounce:true,
+        webvisor:true,
+        trackHash:true
+   });
+</script>
+<noscript><div><img src="https://mc.yandex.ru/watch/83244811" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+<!-- /Yandex.Metrika counter -->

--- a/src/includes/analytics/metrika.njk
+++ b/src/includes/analytics/metrika.njk
@@ -1,14 +1,12 @@
-<!-- Yandex.Metrika counter -->
-<script type="text/javascript" >
-   (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-   m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-   (window, document, "script", "https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js", "ym");
+<script>
+  (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+  m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+  (window, document, 'script', 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js', 'ym')
 
-   ym(83244811, "init", {
-        clickmap:true,
-        trackLinks:true,
-        accurateTrackBounce:true
-   });
+  ym(83244811, 'init', {
+    clickmap:true,
+    trackLinks:true,
+    accurateTrackBounce:true
+  })
 </script>
-<noscript><div><img src="https://mc.yandex.ru/watch/83244811" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
-<!-- /Yandex.Metrika counter -->
+<noscript><img src="https://mc.yandex.ru/watch/83244811" style="position:absolute;left:-9999px" alt=""></noscript>

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -7,6 +7,8 @@
   </head>
   <body class="base__body {{ bodyClass }}">
 
+    {% include "analytics/metrika.njk" %}
+
     {{ content | safe }}
 
     <script type="module" src="/scripts/index.js"></script>


### PR DESCRIPTION
Подключает дефолтную метрику от Яндекса + добавляет альтернативный CDN «Позволяет корректно учитывать посещения из регионов, в которых ограничен доступ к ресурсам Яндекса»