### PR TITLE
Добавляет якоря для мнений авторов

### DIFF
--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -6,10 +6,10 @@
     </h2>
 
     {% for practice in practices %}
-      <article id="practices__{{ practice.fileSlug }}">
+      <article id="practices-{{ practice.fileSlug }}">
         <h3 class="practices__author">
           @{{ practice.fileSlug }}
-          <a href="#practices__{{ practice.fileSlug }}" aria-label="Пример в работе от @{{ practice.fileSlug }}">#</a>
+          <a href="#practices-{{ practice.fileSlug }}" aria-label="Пример в работе от @{{ practice.fileSlug }}">#</a>
         </h3>
         {{ practice.templateContent | safe }}
       </article>

--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -6,13 +6,13 @@
     </h2>
 
     {% for practice in practices %}
-      <section id="practices__{{ practice.fileSlug }}">
+      <article id="practices__{{ practice.fileSlug }}">
         <h3 class="practices__author">
           @{{ practice.fileSlug }}
           <a href="#practices__{{ practice.fileSlug }}" aria-label="Пример в работе от @{{ practice.fileSlug }}">#</a>
         </h3>
         {{ practice.templateContent | safe }}
-      </section>
+      </article>
     {% endfor %}
 
   </section>

--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -6,8 +6,11 @@
     </h2>
 
     {% for practice in practices %}
-      <article>
-        <h3 class="practices__author">@{{ practice.fileSlug }}</h3>
+      <article id="practices__{{ practice.fileSlug }}">
+        <h3 class="practices__author">
+          @{{ practice.fileSlug }}
+          <a href="#practices__{{ practice.fileSlug }}" aria-label="Пример в работе от @{{ practice.fileSlug }}">#</a>
+        </h3>
         {{ practice.templateContent | safe }}
       </article>
     {% endfor %}

--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -6,13 +6,13 @@
     </h2>
 
     {% for practice in practices %}
-      <article id="practices__{{ practice.fileSlug }}">
+      <section id="practices__{{ practice.fileSlug }}">
         <h3 class="practices__author">
           @{{ practice.fileSlug }}
           <a href="#practices__{{ practice.fileSlug }}" aria-label="Пример в работе от @{{ practice.fileSlug }}">#</a>
         </h3>
         {{ practice.templateContent | safe }}
-      </article>
+      </section>
     {% endfor %}
 
   </section>


### PR DESCRIPTION
В блоке «В работе» у мнений авторов не было ссылок-якорей. Этот PR:
- Добавляет якоря для каждого мнения
- Добавляет быстрые ссылки для каждого мнения
- Якоря уникальны
- Якоря содержат уникальный для статьи `aria-label`

Было

<img width="579" alt="Снимок экрана 2021-07-27 в 10 19 30" src="https://user-images.githubusercontent.com/50330458/127112681-0b2e0317-e932-4aeb-aba3-0d8beef828df.png">

Стало


<img width="462" alt="Снимок экрана 2021-07-27 в 10 20 00" src="https://user-images.githubusercontent.com/50330458/127112687-d622a44f-ea34-4253-8dfc-ef0e2869e84a.png">