### PR TITLE
Добавляет хеширование для файлов CSS и JS для инвалидации кэша

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fs = require('fs')
 
 const gulp = require('gulp')
 const git = require('gulp-git')
@@ -10,6 +11,8 @@ const autoprefixer = require('autoprefixer')
 const esbuild = require('gulp-esbuild')
 const replace = require('gulp-replace')
 const del = require('del')
+const rev = require('gulp-rev')
+const revRewrite = require('gulp-rev-rewrite')
 
 const { contentRepGithub, contentRepFolders } = require(path.join(__dirname, 'config/constants'))
 
@@ -62,12 +65,33 @@ const paths = () => {
 
 // Clean
 
-clean = () => {
+const clean = () => {
   return del([
     'dist/styles',
     'dist/scripts',
   ])
 }
+
+// Cache
+const cacheHash = () => {
+  return gulp
+    .src('dist/**/*.{css,js}')
+    .pipe(rev())
+    .pipe(gulp.dest('dist'))
+    .pipe(rev.manifest('rev-manifset.json'))
+    .pipe(gulp.dest('dist'))
+}
+
+const cacheReplace = () => {
+  return gulp
+    .src('dist/**/*.{html,css,svg}')
+    .pipe(revRewrite({
+      manifest: fs.readFileSync('dist/rev-manifset.json')
+    }))
+    .pipe(gulp.dest('dist'));
+}
+
+const cache = gulp.series(cacheHash, cacheReplace)
 
 exports.setupContent = gulp.series(
   cloneContent,
@@ -85,4 +109,5 @@ exports.default = gulp.series(
   scripts,
   paths,
   clean,
+  cache
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -4407,6 +4407,55 @@
         "yargs-parser": ">=5.0.0-security.0"
       }
     },
+    "gulp-rev": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-9.0.0.tgz",
+      "integrity": "sha512-Ytx/uzDA2xNxHlPG8GReS1ut00msd0HlKDk9Ai/0xF2yvg+DAeGRAviCFlQzQmdZtqAoXznYspwWoGEoxDvhyA==",
+      "dev": true,
+      "requires": {
+        "modify-filename": "^1.1.0",
+        "plugin-error": "^1.0.1",
+        "rev-hash": "^2.0.0",
+        "rev-path": "^2.0.0",
+        "sort-keys": "^2.0.0",
+        "through2": "^2.0.0",
+        "vinyl": "^2.1.0",
+        "vinyl-file": "^3.0.0"
+      }
+    },
+    "gulp-rev-rewrite": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev-rewrite/-/gulp-rev-rewrite-4.0.0.tgz",
+      "integrity": "sha512-KbyC2epeYS6ZUG2yOwEbE8vriARhJ3259cgVCtiM3CQyX8k/ntGKS1lY5QhIyNWYTt7+X9jDsXYeXugPexGJ6w==",
+      "dev": true,
+      "requires": {
+        "lodash.escaperegexp": "^4.1.2",
+        "plugin-error": "^1.0.1",
+        "through2": "^4.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "through2": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+          "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "3"
+          }
+        }
+      }
+    },
     "gulp-shell": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/gulp-shell/-/gulp-shell-0.8.0.tgz",
@@ -5699,6 +5748,12 @@
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
       "dev": true
     },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
+      "dev": true
+    },
     "lodash.forown": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-4.4.0.tgz",
@@ -6395,6 +6450,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
+    "modify-filename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
+      "integrity": "sha1-mi3sg4Bvuy2XXyK+7IWcoms5OqE=",
       "dev": true
     },
     "moo": {
@@ -25181,6 +25242,21 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rev-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-2.0.0.tgz",
+      "integrity": "sha1-dyCiNu0MJY3z5kvsA+wEiwW5JMQ=",
+      "dev": true
+    },
+    "rev-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rev-path/-/rev-path-2.0.0.tgz",
+      "integrity": "sha512-G5R2L9gYu9kEuqPfIFgO9gO+OhBWOAT83HyauOQmGHO6y9Fsa4acv+XsmNhNDrod0HDh1/VxJRmsffThzeHJlQ==",
+      "dev": true,
+      "requires": {
+        "modify-filename": "^1.0.0"
+      }
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -25753,6 +25829,23 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         }
       }
@@ -27117,6 +27210,31 @@
         "cloneable-readable": "^1.0.0",
         "remove-trailing-separator": "^1.0.1",
         "replace-ext": "^1.0.0"
+      }
+    },
+    "vinyl-file": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-3.0.0.tgz",
+      "integrity": "sha1-sQTZ5ECf+jJfqt1SBkLQo7SIs2U=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.3.0",
+        "strip-bom-buf": "^1.0.0",
+        "strip-bom-stream": "^2.0.0",
+        "vinyl": "^2.0.1"
+      },
+      "dependencies": {
+        "strip-bom-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+          "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+          "dev": true,
+          "requires": {
+            "first-chunk-stream": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        }
       }
     },
     "vinyl-fs": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "gulp-git": "^2.10.1",
     "gulp-postcss": "^9.0.0",
     "gulp-replace": "^1.1.3",
+    "gulp-rev": "^9.0.0",
+    "gulp-rev-rewrite": "^4.0.0",
     "gulp-shell": "^0.8.0",
     "html-minifier": "^4.0.0",
     "linkedom": "^0.11.0",


### PR DESCRIPTION
Для файлов стилей и скриптов добавляет хеш типа `index.css -> index-hash1234.css` для сброса кэша в бразуерах.

Для этого используется два пакета для gulp - один создаёт файл-манифест с хешами для нужных файлов, другой заменяет url на эти файлы, используя этот манифест.

В будущем, это решение может быть спорным, так как из-за малого размера файлов и для повышения рейтинга в поисковых выдачах эти файлы можно инлайнить в тело html-страничек.