### PR TITLE
Добавляет cross-env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2459,6 +2459,15 @@
         "parse-json": "^4.0.0"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "url": "https://github.com/doka-guide/platform"
   },
   "scripts": {
-    "start": "NODE_ENV=development eleventy --serve --quiet",
-    "build": "NODE_ENV=production eleventy --quiet && npx gulp",
+    "start": "cross-env NODE_ENV=development eleventy --serve --quiet",
+    "build": "cross-env NODE_ENV=production eleventy --quiet && npx gulp",
     "netlify": "npx gulp setupContent && npm run build && npx gulp dropContent",
     "editorconfig": "editorconfig-checker",
     "test": "npm run editorconfig"
@@ -34,6 +34,7 @@
     "@11ty/eleventy": "^0.12.1",
     "@11ty/eleventy-img": "^0.9.0",
     "autoprefixer": "^10.2.6",
+    "cross-env": "^7.0.3",
     "del": "^6.0.0",
     "dotenv": "^10.0.0",
     "esbuild": "^0.12.9",


### PR DESCRIPTION
Если у пользователя не установлена подсистема Linux для Windows (а значит и Linux-версия Bash), пользователь сталкивается с проблемой:

```bash
"NODE_ENV" не является внутренней или внешней
командой, исполняемой программой или пакетным файлом.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ start: `NODE_ENV=development eleventy --serve --quiet`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @ start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

Лучше не заставлять пользователя ставить подсистему Linux, которая ему может быть не нужна, а воспользоваться [пакетом cross-env](https://www.npmjs.com/package/cross-env), который предназначен для решения проблемы.