### PR TITLE
Добавляет фильтр для копирования файлов демок

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -276,7 +276,7 @@ module.exports = function(config) {
   config.addPassthroughCopy('src/robots.txt')
   config.addPassthroughCopy('src/fonts')
   config.addPassthroughCopy('src/**/*.(html|gif|jpg|png|svg|mp4|webm|zip)')
-  config.addPassthroughCopy('src/(css|html|js|tools)/**/demos/**/*.(css|js)')
+  config.addPassthroughCopy('src/(css|html|js|tools)/**/demos/**/*')
 
   return {
     dir: {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -276,6 +276,7 @@ module.exports = function(config) {
   config.addPassthroughCopy('src/robots.txt')
   config.addPassthroughCopy('src/fonts')
   config.addPassthroughCopy('src/**/*.(html|gif|jpg|png|svg|mp4|webm|zip)')
+  config.addPassthroughCopy('src/(css|html|js|tools)/**/demos/**/*.(css|js)')
 
   return {
     dir: {


### PR DESCRIPTION
В связи с [обсуждением](https://github.com/doka-guide/content/discussions/1343) стало очевидным, что нужно копировать файлы демок все, а не только `html` и картинки с архивами.