### PR TITLE
Рефактор блоков с кодом

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -89,7 +89,9 @@ module.exports = function(config) {
     breaks: true,
     linkify: true,
     highlight: function(str, lang) {
-      return `<pre data-lang="${lang}"><code class="language-${lang}">${markdownLibrary.utils.escapeHtml(str)}</code></pre>`
+      const dataAttribute = lang ? `data-lang="${lang}"`: ''
+      const classAttribute = lang ? `class="language-${lang}"` : ''
+      return `<pre ${dataAttribute}><code ${classAttribute}>${markdownLibrary.utils.escapeHtml(str)}</code></pre>`
     }
   })
   config.setLibrary('md', markdownLibrary)

--- a/src/styles/blocks/code-block.css
+++ b/src/styles/blocks/code-block.css
@@ -1,24 +1,27 @@
 .code-block {
   counter-reset: line-count 0;
   overflow: auto;
+  white-space: pre;
 }
 
 .code-block__content {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  font-family: var(--font-family, monospace);
+  border-collapse: collapse;
+  font-size: var(--font-size-s);
+  line-height: calc(24 / 18);
   letter-spacing: var(--letter-spacing);
+  font-family: var(--font-family, monospace);
 }
 
-.code-block__line {
-  display: contents;
-}
+.code-block__origin {}
+
+.code-block__line {}
 
 .code-block__line-number {
   position: sticky;
   left: 0;
   padding-right: 0.83em;
-  display: inline-block;
+  vertical-align: baseline;
+  font-weight: normal;
   text-align: end;
   background-color: hsla(var(--color-base-background) / 0.92);
 }
@@ -29,6 +32,6 @@
   opacity: 0.6;
 }
 
-.code-block__line-content {}
-
-/* TODO: тема для подсветки кода */
+.code-block__line-content {
+  vertical-align: baseline;
+}

--- a/src/styles/code-dark-theme.css
+++ b/src/styles/code-dark-theme.css
@@ -1,0 +1,94 @@
+/*
+
+Atom One Dark by Daniel Gamage
+Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
+
+base:    #282c34
+mono-1:  #abb2bf
+mono-2:  #818896
+mono-3:  #5c6370
+hue-1:   #56b6c2
+hue-2:   #61aeee
+hue-3:   #c678dd
+hue-4:   #98c379
+hue-5:   #e06c75
+hue-5-2: #be5046
+hue-6:   #d19a66
+hue-6-2: #e6c07b
+
+*/
+
+.hljs {
+  color: #abb2bf;
+  background: #282c34;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #5c6370;
+  font-style: italic;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula {
+  color: #c678dd;
+}
+
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #e06c75;
+}
+
+.hljs-literal {
+  color: #56b6c2;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #98c379;
+}
+
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #d19a66;
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #61aeee;
+}
+
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #e6c07b;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}

--- a/src/styles/code-light-theme.css
+++ b/src/styles/code-light-theme.css
@@ -1,0 +1,94 @@
+/*
+
+Atom One Light by Daniel Gamage
+Original One Light Syntax theme from https://github.com/atom/one-light-syntax
+
+base:    #fafafa
+mono-1:  #383a42
+mono-2:  #686b77
+mono-3:  #a0a1a7
+hue-1:   #0184bb
+hue-2:   #4078f2
+hue-3:   #a626a4
+hue-4:   #50a14f
+hue-5:   #e45649
+hue-5-2: #c91243
+hue-6:   #986801
+hue-6-2: #c18401
+
+*/
+
+.hljs {
+  color: #383a42;
+  background: #fafafa;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #a0a1a7;
+  font-style: italic;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula {
+  color: #a626a4;
+}
+
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #e45649;
+}
+
+.hljs-literal {
+  color: #0184bb;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #50a14f;
+}
+
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #986801;
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #4078f2;
+}
+
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c18401;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}

--- a/src/styles/dark-theme.css
+++ b/src/styles/dark-theme.css
@@ -1,3 +1,5 @@
+@import 'code-dark-theme.css';
+
 /* настройки для тёмной темы */
 :root {
   --is-light-theme-on: 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -44,3 +44,4 @@
 @import 'blocks/standalone-page.css';
 @import 'blocks/content.css';
 @import 'blocks/all-articles.css';
+@import 'code-light-theme.css';


### PR DESCRIPTION
- пока нет дизайна для оформления кода добавлены темы _one light_ и _one dark_

- вместо замещения оригинального блока с кодом делается его копия и добавляется отдельный блок с номерами строк - это позволить проще реализовывать копирование сниппета кода

- нумерация сделана в виде таблицы