### PR TITLE
Фикс бага в Safari для `column-reverse` и `gap`

### DIFF
--- a/src/styles/blocks/footer.css
+++ b/src/styles/blocks/footer.css
@@ -30,7 +30,7 @@
 @media not all and (min-width: 768px) {
   .footer {
     align-items: flex-start;
-    flex-direction: column-reverse;
+    flex-direction: column;
   }
 
   .footer__theme-toggle,
@@ -44,5 +44,6 @@
 
   .footer__theme-toggle {
     gap: 4px;
+    order: 1;
   }
 }


### PR DESCRIPTION
Safari некорректно показывает [flex-контейнер с `column-reverse` и `gap`](https://bugs.webkit.org/show_bug.cgi?id=225278)