### PR TITLE
Добавляет типы страниц для Schema

### DIFF
--- a/src/data/pageType.js
+++ b/src/data/pageType.js
@@ -1,0 +1,1 @@
+module.exports = 'WebPage'

--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -1,5 +1,3 @@
-{% set regExp = r/(css|html|js|tools).*/g %}
-
 {% macro authorsList(list) %}[{% for personItem in list %}{
   "@type": "Person",
   "name": "{{ personItem.data.name }}"
@@ -52,7 +50,7 @@
   <meta property="twitter:image:alt" content="{{ doc.data.cover.alt }}">
 {% endif %}
 
-{% if regExp.test(page.url) %}
+{% if pageType === 'Article' %}
   <meta property="og:type" content="article">
   <meta property="article:section" content="Technology">
   <meta property="article:opinion" content="{{ containsPractice }}">

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="base font-theme" lang="{{ meta.lang }}">
+<html class="base font-theme" lang="{{ meta.lang }}" itemscope itemtype="https://schema.org/{{ pageType }}">
   <head>
 
     {% include "meta.njk" %}

--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -38,6 +38,8 @@ module.exports = {
 
   permalink: '/{{doc.filePathStem}}.html',
 
+  pageType: 'Article',
+
   eleventyComputed: {
     title: function(data) {
       const { doc } = data


### PR DESCRIPTION
По умолчанию добавляет всем страницам `itemtype="https://schema.org/WebPage"`. Статьям - `itemtype="https://schema.org/Article"`

PR cвязан с этой [задачей](https://github.com/doka-guide/platform/issues/341)