### PR TITLE
Фикс багов с рендером тегов `<code>`

### DIFF
--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -219,10 +219,6 @@ document.addEventListener('DOMContentLoaded', function () {
   assignFacetFields(SEARCH_CATEGORY_SELECTOR, SEARCH_TAG_SELECTOR, SEARCH_HITS_SELECTOR)
 })
 
-function isDoka(hitObject) {
-  return hitObject.tags.includes('doka')
-}
-
 function isPlaceholder(hitObject) {
   return hitObject.tags.includes('placeholder')
 }
@@ -232,11 +228,12 @@ const templates = {
 
   hit: (hitObject, query, limit) => {
     const editIcon = isPlaceholder(hitObject) ? '<img class="search-hit__edit" src="/images/edit-icon.svg" alt="" width="0.5em" height="0.5em">' : ''
+    const title = hitObject.title.replace(/`(.*?)`/g, '<code class="search-hit__link-code">$1</code>')
 
     return `<article class="search-hit">
-      <h3 class="search-hit__title ${isDoka(hitObject) ? 'font-theme font-theme--code' : ''}">
+      <h3 class="search-hit__title">
         <a class="search-hit__link link" href="${hitObject.url}">
-          ${editIcon}${markQuery(escape(hitObject.title), query)}
+          ${editIcon}${markQuery(title, query)}
         </a>
       </h3>
       <div class="search-hit__summary">

--- a/src/styles/blocks/articles-group.css
+++ b/src/styles/blocks/articles-group.css
@@ -21,8 +21,6 @@
 }
 
 .articles-group__link {
-  display: inline-flex;
-  vertical-align: top;
   font-size: var(--font-size-m);
   line-height: var(--font-line-height-m);
   font-family: var(--font-family);

--- a/src/styles/blocks/search-hit.css
+++ b/src/styles/blocks/search-hit.css
@@ -29,6 +29,13 @@
   right: 0;
 }
 
+.search-hit__link-code {
+  font-size: var(--font-size-l);
+  line-height: var(--font-line-height-l);
+  letter-spacing: var(--letter-spacing);
+  font-family: var(--font-family);
+}
+
 .search-hit__edit {
   margin-right: 0.1em;
   position: relative;


### PR DESCRIPTION
- устраняет  слипание слов в названиях статей в индексах
- рендерит теги `code` в результатах поиска