### PR TITLE
Добавляет обработку множественных бэктиков

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5461,8 +5461,7 @@
     "html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-      "dev": true
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
     },
     "html-tags": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5461,7 +5461,8 @@
     "html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
-      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true
     },
     "html-tags": {
       "version": "3.1.0",

--- a/src/transforms/code-transform.js
+++ b/src/transforms/code-transform.js
@@ -83,11 +83,6 @@ module.exports = function(window) {
           parentElement.querySelectorAll('code').forEach(codeElement => {
             codeElement.classList.add(codeClass, 'font-theme', 'font-theme--code')
           })
-          codeElement.forEach(element => {
-            if (element) {
-              element.classList.add(codeClass, 'font-theme', 'font-theme--code')
-            }
-          })
         })
     }
   }

--- a/src/transforms/code-transform.js
+++ b/src/transforms/code-transform.js
@@ -80,7 +80,9 @@ module.exports = function(window) {
     for (const [parentClass, codeClass] of Object.entries(classMap)) {
       window.document.querySelectorAll(`.${parentClass}`)
         .forEach(parentElement => {
-          const codeElement = parentElement.querySelectorAll('code')
+          parentElement.querySelectorAll('code').forEach(codeElement => {
+            codeElement.classList.add(codeClass, 'font-theme', 'font-theme--code')
+          })
           codeElement.forEach(element => {
             if (element) {
               element.classList.add(codeClass, 'font-theme', 'font-theme--code')

--- a/src/transforms/code-transform.js
+++ b/src/transforms/code-transform.js
@@ -80,10 +80,12 @@ module.exports = function(window) {
     for (const [parentClass, codeClass] of Object.entries(classMap)) {
       window.document.querySelectorAll(`.${parentClass}`)
         .forEach(parentElement => {
-          const codeElement = parentElement.querySelector('code')
-          if (codeElement) {
-            codeElement.classList.add(codeClass, 'font-theme', 'font-theme--code')
-          }
+          const codeElement = parentElement.querySelectorAll('code')
+          codeElement.forEach(element => {
+            if (element) {
+              element.classList.add(codeClass, 'font-theme', 'font-theme--code')
+            }
+          })
         })
     }
   }


### PR DESCRIPTION
Если в заголовке статьи больше одного слова с бэктиками, классы для стилей добавляются только к первому. 

Пример [статья js/try...catch](https://github.com/doka-guide/content/blob/main/js/try-catch/index.md)

```njk
---
title: "`try`...`catch`"
```

БЫЛО

```html
<h1 class="article__title">
    <code class="article__title-code font-theme font-theme--code">try</code>...<code>catch</code>
</h1>
```

```html
<li>
    <a class="articles-group__link link" href="/js/try-catch/">
        <code class="articles-group__code font-theme font-theme--code">try</code>...<code>catch</code>
    </a>
</li>
```

СТАЛО

```html
<h1 class="article__title">
    <code class="article__title-code font-theme font-theme--code">try</code>...<code class="article__title-code font-theme font-theme--code">catch</code>
</h1>
```

```html
<li>
    <a class="articles-group__link link" href="/js/try-catch/">
        <code class="articles-group__code font-theme font-theme--code">try</code>...<code class="articles-group__code font-theme font-theme--code">catch</code>
    </a>
</li>
```