### PR TITLE
Предотвращает вывод пустых групп в индексе

### DIFF
--- a/src/views/article-index.11tydata.js
+++ b/src/views/article-index.11tydata.js
@@ -93,7 +93,7 @@ module.exports = {
           name: 'Остальные',
           items: restArticles
         }
-      ]
+      ].filter(group => group.items.length > 0)
     }
   }
 }


### PR DESCRIPTION
Есть вероятность, что в какой-то момент в группе "Остальные" не будет статей, поэтому добавляется проверка на количество элементов.