### PR TITLE
Небольшие правки вёрстки

### DIFF
--- a/src/styles/blocks/article.css
+++ b/src/styles/blocks/article.css
@@ -186,6 +186,8 @@
   .article__content {
     grid-column-start: 2;
     grid-column-end: span 1;
+    padding-top: var(--offset);
+    padding-bottom: var(--offset);
   }
 
   .article--with-cover {}

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -13,7 +13,9 @@
   margin-bottom: 10px;
 }
 
-.content img {
+.content img,
+.content video,
+.content audio {
   display: block;
   max-width: 100%;
   height: auto;

--- a/src/styles/blocks/doc.css
+++ b/src/styles/blocks/doc.css
@@ -42,7 +42,7 @@
   }
 }
 
-@media (min-width: 1900px) {
+@media (min-width: 2000px) {
   .doc {
     --columns-template: var(--aside-with) 1fr var(--aside-with);
   }


### PR DESCRIPTION
- Предотвращает переполнение из-за тегов `video`, `audio`
- Возвращает случайно удаленные вертикальные отступы для контента статьи
- Увеличивает брейкпойнт для центрирования на широких мониторах