### PR TITLE
Раскоменчивает вывод зафичеренных статей

### DIFF
--- a/src/views/index.11tydata.js
+++ b/src/views/index.11tydata.js
@@ -17,8 +17,7 @@ module.exports = {
       // массив массивов
       const allFeaturedArticles = mainSections.map(section =>
         data.collections[section]
-          // TODO: uncomment
-          // .filter(article => hasTag(article.data.tags, data.featuredTag))
+          .filter(article => hasTag(article.data.tags, data.featuredTag))
           .slice(0, data.featuredArticlesMaxCount)
       )
 


### PR DESCRIPTION
В контенте [отметили зафичеренные статьи](https://github.com/doka-guide/content/pull/1598). Этот PR выводит на главной зафичеренные статьи.