### PR TITLE
Правки для блока `<code>`

### DIFF
--- a/src/styles/blocks/callout.css
+++ b/src/styles/blocks/callout.css
@@ -6,6 +6,7 @@
   align-items: baseline;
   gap: 10px;
   padding: var(--padding);
+  overflow-wrap: break-word;
   padding-right: 3em;
   border-radius: 6px;
   background-color: hsl(0 0% var(--lightness));

--- a/src/styles/blocks/callout.css
+++ b/src/styles/blocks/callout.css
@@ -19,6 +19,10 @@
   flex: 1 1 360px;
 }
 
+.callout__content .code {
+  --lightness: calc(var(--is-light-theme-on) * 100%);
+}
+
 @media (min-width: 1366px) {
   .callout {
     --padding: 20px;

--- a/src/styles/blocks/code.css
+++ b/src/styles/blocks/code.css
@@ -1,7 +1,6 @@
 .code {
   --lightness: calc(var(--is-dark-theme-on) * 20% + var(--is-light-theme-on) * 92%);
-  display: inline-block;
-  padding: 0 12px;
+  padding: 0.025em 0.35em;
   font-size: var(--font-size-m);
   line-height: var(--font-line-height-m);
   font-family: var(--font-family);


### PR DESCRIPTION
- Правки размеров
- Правка фонового цвета внутри callout
- принудительный перенос текста

Fix: #392, #395, #390