### PR TITLE
Меняет настройки CSSO

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,9 @@ const styles = () => {
     .pipe(postcss([
       pimport,
       autoprefixer,
-      csso,
+      csso({
+        restructure: false
+      }),
     ]))
     .pipe(gulp.dest('dist/styles'))
 }


### PR DESCRIPTION
У CSSO по умолчанию включена опция `restructure: true`, которая может склеивать селекторы. К багам это не приводило, но может, плюс это затрудняет отладку в production-режиме.