### PR TITLE
Правит вычисление `docPath`

### DIFF
--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -71,7 +71,8 @@ module.exports = {
 
     docPath: function(data) {
       const { doc } = data
-      return doc.filePathStem.replace('index', '')
+      // Удаляем `/index` с конца пути
+      return doc.filePathStem.replace('/index', '')
     },
 
     category: function(data) {


### PR DESCRIPTION
Уточняет вычисление docPath. Например, для статьи `/css/z-index/index` ранее преобразовывался в `/css/z-/index`.