### PR TITLE
Правит метод поиска практик для статьи

### DIFF
--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -98,7 +98,7 @@ module.exports = {
       const { docPath } = data
 
       return allPractices.filter(practice => {
-        return practice.filePathStem.includes(docPath)
+        return practice.filePathStem.startsWith(`${docPath}/practice`)
       })
     },
 


### PR DESCRIPTION
Fix: #440

Раньше проверялось просто вхождение подстроки, из-за чего пути `/js/string` и `js/string-length` считались одинаковыми.