### PR TITLE
Убирает подчёркивание при наведении в Safari 15

### DIFF
--- a/src/styles/blocks/featured-article.css
+++ b/src/styles/blocks/featured-article.css
@@ -42,6 +42,7 @@
 
 .featured-article__link:hover {
   --stroke-opacity: 0;
+  --stroke-width: 0;
 }
 
 .featured-article__link::after {


### PR DESCRIPTION
Чинит  #450

Было (смотреть левый квадрат):
<img width="1369" alt="Screenshot 2021-09-27 at 22 13 00" src="https://user-images.githubusercontent.com/50330458/134972538-e1b3ab5f-c40a-4bce-9164-f75454f8c25d.png">

Стало (смотреть левый квадрат):
<img width="1369" alt="Screenshot 2021-09-27 at 22 29 21" src="https://user-images.githubusercontent.com/50330458/134972548-6247f747-1743-4dbf-ba7e-8b90d2868ca7.png">
