### PR TITLE
Убирает `title` со ссылок на зафичеренных статьях на главной

### DIFF
--- a/src/includes/blocks/featured-article.njk
+++ b/src/includes/blocks/featured-article.njk
@@ -6,7 +6,7 @@
       <img class="featured-article__image" src="{{ article.link }}/{{ article.cover.mobile }}" alt="">
     {% endif %}
     <h3 class="featured-article__title">
-      <a class="featured-article__link link" href="{{ article.link }}" title="{{ article.linkTitle }}">
+      <a class="featured-article__link link" href="{{ article.link }}">
         {{ article.title | titleMarkdown | safe }}
       </a>
     </h3>


### PR DESCRIPTION
Убирает лишнюю подсказку, которая мешала чтению.