### PR TITLE
Добавляет `oveflow: hidden` для кнопки для предотвращения выпадания псевдоэлемента при hover'е

### DIFF
--- a/src/styles/blocks/button.css
+++ b/src/styles/blocks/button.css
@@ -11,6 +11,7 @@
   position: relative;
   z-index: 0;
   appearance: none;
+  overflow: hidden;
   display: inline-block;
   box-sizing: border-box;
   padding: 0.5em 1.33em;


### PR DESCRIPTION
Hover эффект создается с помощью псевдоэлемента для удобства управления цветом. Из-за закруглений самой кнопки этот элемент вылазит за пределы кнопки.

Вместо `overflow: hidden` можно использовать наследование `border-radius`