### PR TITLE
Меняет эффект наведения ссылок автодополнения поиска для контрастности

### DIFF
--- a/src/styles/blocks/suggestion-list.css
+++ b/src/styles/blocks/suggestion-list.css
@@ -26,11 +26,24 @@
 .suggestion-list__link {
   --stroke-width: 2px;
   --stroke-color: var(--accent-color);
+  position: relative;
+  z-index: 0;
   text-underline-position: auto;
   text-underline-offset: 0.2em;
   color: inherit;
 }
 
-.suggestion-list__link:hover {
-  color: var(--accent-color);
+.suggestion-list__link::before {
+  content: '';
+  opacity: 0;
+  position: absolute;
+  z-index: -1;
+  inset: -0.15em;
+  border-radius: 6px;
+  background-color: var(--accent-color);
+  transition: opacity 125ms;
+}
+
+.suggestion-list__link:hover::before {
+  opacity: 1;
 }


### PR DESCRIPTION
Fix: #499

![image](https://user-images.githubusercontent.com/6412192/136576398-6026aa74-ebe1-47b5-8c69-5dfca7a5da1e.png)
