### PR TITLE
Добавляет принудительный перенос текста ссылкам в контенте для предотвращения переполнения

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -99,6 +99,10 @@
   margin-block: var(--offset);
 }
 
+.content .link {
+  overflow-wrap: break-word;
+}
+
 @media (max-height: 640px) {
   .content iframe {
     max-height: calc(100vh - var(--header-height, 0) * 1px - 3em);


### PR DESCRIPTION
Как пример, такое может быть, если в качестве текста используется URL

Fix: #382