### PR TITLE
Скрывает блок контрибьюторов, если их нет

### DIFF
--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -8,11 +8,7 @@ function getPersons(personGetter) {
       ? personGetter(doc)
       : doc.data[personGetter]
 
-    if (!persons) {
-      return [];
-    }
-
-    return Array.isArray(persons) ? persons : [persons]
+    return (Array.isArray(persons) ? persons : [persons]).filter(Boolean)
   }
 }
 


### PR DESCRIPTION
Сейчас отображается блок контрибьюторов, даже если их нет, что довольно некрасиво:

![image](https://user-images.githubusercontent.com/4408379/136961809-3f9d950e-433e-4eda-8e9a-476ef1ed549a.png)

https://doka.guide/css/box-shadow/

| Before   | After    |
| -------- | -------- |
| ![image](https://user-images.githubusercontent.com/4408379/136961397-7302b222-4364-4267-ad95-5fab23801326.png) | ![image](https://user-images.githubusercontent.com/4408379/136961451-6044ecfc-42e8-4c98-9921-186066f08812.png) |