### PR TITLE
Убирает атрибут autocomplete у радиокнопок

### DIFF
--- a/src/views/article-index.njk
+++ b/src/views/article-index.njk
@@ -31,11 +31,11 @@
 
       <div class="index-block__filter-control switch">
         <label class="switch__item">
-          <input class="switch__input" type="radio" name="index-filter" value="themes" autocomplete="off" checked>
+          <input class="switch__input" type="radio" name="index-filter" value="themes" checked>
           <span class="switch__label">Темам</span>
         </label>
         <label class="switch__item">
-          <input class="switch__input" type="radio" name="index-filter" value="alphabet" autocomplete="off">
+          <input class="switch__input" type="radio" name="index-filter" value="alphabet">
           <span class="switch__label">Алфавиту</span>
         </label>
       </div>


### PR DESCRIPTION

Атрибут `autocomplete` не применяется к радиокнопкам (см. https://docs.w3cub.com/html/element/input#htmlattrdefautocomplete)