### PR TITLE
Удаляет пустые атрибуты у логотипа поиска

### DIFF
--- a/src/views/search.njk
+++ b/src/views/search.njk
@@ -43,7 +43,7 @@ title: 'Дока — Поиск'
       <div class="search-page__algolia">
         <a class="algolia-block" href="https://www.algolia.com/" target="_blank" rel="noopener noreferrer">
           <span class="algolia-block__text">Поиск работает с помощью</span>
-          <img class="algolia-block__image" src="/images/algolia-logo.svg" width="" height="" alt="Логотип Algolia">
+          <img class="algolia-block__image" src="/images/algolia-logo.svg" alt="Логотип Algolia">
         </a>
       </div>
 


### PR DESCRIPTION
Не разрешено использовать пустые значения в атрибутах width/height.
