### PR TITLE
Добавляет постфикс к id заголовка

### DIFF
--- a/src/transforms/headings-transform.js
+++ b/src/transforms/headings-transform.js
@@ -10,6 +10,8 @@ module.exports = function(window) {
   if (content) {
     let headings = content.querySelectorAll('h2, h3, h4, h5, h6')
 
+    const headingHashMap = {};
+
     for (const heading of headings) {
       const clonedHeading = heading.cloneNode(true)
 
@@ -20,7 +22,15 @@ module.exports = function(window) {
       const headingText = heading.textContent.trim()
       const level = heading.tagName.slice(1)
       const id = slugify(headingText)
-      clonedHeading.setAttribute('id', slugify(headingText))
+
+      if (headingHashMap[id] >= 0) {
+        headingHashMap[id] += 1;
+      } else {
+        headingHashMap[id] = 0;
+      }
+      const headingIdPostfix = headingHashMap[id] > 0 ? `-${headingHashMap[id]}` : ''
+
+      clonedHeading.setAttribute('id', slugify(headingText) + headingIdPostfix)
       clonedHeading.setAttribute('tabindex', -1)
       clonedHeading.classList.add('article-heading__title')
 


### PR DESCRIPTION
Решает #540.

К одинаковым заголовкам добавляется постфикс `-NUMBER`, где `NUMBER` — номер встречающейся копии. Сделал по аналогии с тем, как GitHub решает коллизии.