### PR TITLE
Предотвращает фокус на пунктах меню, когда оно закрыто

### DIFF
--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -28,7 +28,9 @@ function init() {
 
   document.addEventListener('keyup', (event) => {
     if (event.code === 'Slash') {
-      input?.focus()
+      setTimeout(() => {
+        input?.focus()
+      })
     }
   })
 

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -1,6 +1,7 @@
 .header {
   --header-bg-color: var(--accent-color, var(--color-background));
   --search-input-height: 1.1em;
+  --header-animation-time: 0.6s;
   position: relative;
   z-index: 1;
   background-color: var(--color-background);
@@ -9,14 +10,16 @@
 .header::before {
   content: '';
   position: fixed;
+  z-index: 1;
   opacity: 0.3;
-  z-index: -1;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
   background-color: var(--color-text);
-  transition: opacity 0.6s, visibility 0.6s;
+  transition:
+    opacity var(--header-animation-time),
+    visibility var(--header-animation-time);
 }
 
 .header__inner {
@@ -59,7 +62,10 @@
   line-height: var(--font-line-height-xl);
   letter-spacing: var(--letter-spacing);
   background-color: var(--color-background);
-  transition: transform 0.6s cubic-bezier(0.65, 0.05, 0.36, 1), opacity 0s;
+  transition:
+    transform var(--header-animation-time) cubic-bezier(0.65, 0.05, 0.36, 1),
+    opacity 0s,
+    visibility 0s;
 }
 
 .header__breadcrumbs {
@@ -153,7 +159,7 @@
 
 .header--animating {
   animation-name: fixedHeaderAnimation;
-  animation-duration: 0.6s;
+  animation-duration: var(--header-animation-time);
   animation-fill-mode: both;
   animation-timing-function: cubic-bezier(0.65, 0.05, 0.36, 1);
 }
@@ -201,14 +207,13 @@
 .header:not(.header--open, .header--static) .header__inner--menu {
   transform: translateY(-100%);
   opacity: 0;
-  pointer-events: none;
-  transition-delay: 0s, 0.6s;
+  visibility: hidden;
+  transition-delay: 0s, var(--header-animation-time), var(--header-animation-time);
 }
 
 .header:not(.header--open)::before {
   opacity: 0;
   visibility: hidden;
-  transition-delay: 0s;
 }
 
 .header--static .header__inner--menu {


### PR DESCRIPTION
Fix: #539

Добавлено скрытие меню с помощью`visibility: hidden;` и чтобы подождать его появеления фокус на поле ввода ставится через `setTimeout`