### PR TITLE
базовый черный цвет стал менее агрессивным

### DIFF
--- a/src/styles/base-colors.css
+++ b/src/styles/base-colors.css
@@ -3,7 +3,7 @@
   color-scheme: light dark;
 
   --color-light: 0 0% 100%;
-  --color-dark: 0 0% 0%;
+  --color-dark: 180, 10%, 6%;
 
   --color-orange: 25 100% 59%;
   --color-blue: 209 100% 59%;


### PR DESCRIPTION
Черный цвет на сайте (#000) никогда не встречается в природе, от чего такой черный воспринимается не интуитивно глазом, заменил его на более мягкий (#0e1111)


| До  | После  |
|---|---|
|![image](https://user-images.githubusercontent.com/6636655/137133992-48bfa583-3c2a-415b-aedd-0f64f074287a.png)|![image](https://user-images.githubusercontent.com/6636655/137133183-50c58ada-4f0c-44d6-bb4b-715da635c404.png)|

[почитать про цвет](https://www.shutterstock.com/blog/history-theory-palettes-color-black) 