### PR TITLE
Предзагружает прямое и моноширинное

### DIFF
--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -8,6 +8,10 @@
 <meta name="robots" content="index, nofollow">
 
 <title>{{ documentTitle }}</title>
+
+<link rel="preload" href="/fonts/graphik/graphik-regular.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="/fonts/spot-mono/spot-mono-light.woff2" as="font" type="font/woff2" crossorigin>
+
 <meta itemprop="name" content="{{ documentTitle }}">
 <meta property="og:title" content="{{ documentTitle }}">
 <meta property="twitter:title" content="{{ documentTitle }}">


### PR DESCRIPTION
Они всё равно загружаются, а так браузер узнает о шрифтах раньше и поставит их в загрузку.

Курсивное и жирное начертания в предзагрузку не ставлю, они могут загрузиться потом.