### PR TITLE
Убирает перекрытие некоторых букв  подчеркиванием у элементов главной навигации

### DIFF
--- a/src/styles/blocks/nav-list.css
+++ b/src/styles/blocks/nav-list.css
@@ -47,9 +47,9 @@
 }
 
 .nav-list__link-text::after {
+  content: '';
   position: relative;
   z-index: -1;
-  content: '';
   display: block;
   height: var(--stroke-size);
   background-color: var(--accent-color);


### PR DESCRIPTION
fix: https://github.com/doka-guide/platform/issues/564