### PR TITLE
Исправляет выделение внутри цитат

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -50,6 +50,7 @@
       0.4 * var(--is-dark-theme-on)
     );
   position: absolute;
+  z-index: -1;
   inset: 0;
   background-color: var(--accent-color);
 }


### PR DESCRIPTION

Нельзя выделить текст внутри цитаты. После этого пул-реквеста, это будет возможно:

Пример: https://doka.guide/css/cascade/


![image](https://user-images.githubusercontent.com/4408379/137164860-66afff80-4dc2-4956-a309-a10bbd554054.png)
