### PR TITLE
Чинит показ результатов поиска с html разметкой внутри

### DIFF
--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -385,7 +385,7 @@ const templates = {
         </a>
       </h3>
       <div class="search-hit__summary">
-        ${markQuery(adjustTextSize(escapeText(hitObject.summary, '<code class="search-hit__text-code font-theme font-theme--code">$1</code>'), query, limit), query)}
+        ${markQuery(escapeText(adjustTextSize(hitObject.summary, query, limit), '<code class="search-hit__text-code font-theme font-theme--code">$1</code>'), query)}
       </div>
     </article>
   `


### PR DESCRIPTION
fixes #572 

Меняем порядок применения функций обрезки и подсветки html тегов: сначала обрезаем строку до нужного размера, затем расставляем <code></code> в нужных местах. 