### PR TITLE
Правит глазки на те, что есть в шрифте

### DIFF
--- a/src/includes/blocks/logo.njk
+++ b/src/includes/blocks/logo.njk
@@ -13,7 +13,9 @@
   <{{tag}} class="{{ classes }}" {{ attrs }}>
     {% if (not isImageHidden) %}
       <div class="logo__image" aria-hidden="true">
-        <div class="logo__symbols">U·ᴥ·U</div>
+        <div class="logo__symbols">
+          U<span class="logo__eye">·</span>ᴥ<span class="logo__eye">·</span>U
+        </div>
       </div>
     {% endif %}
     <div class="logo__text {{ 'link' if isLink else '' }}">Дока</div>

--- a/src/styles/blocks/logo.css
+++ b/src/styles/blocks/logo.css
@@ -29,6 +29,11 @@
   text-decoration: none;
 }
 
+.logo__eye {
+  position: relative;
+  top: -0.05em;
+}
+
 .logo__text {
   --stroke-width: 2px;
   margin-left: 6px;


### PR DESCRIPTION
К сожалению, существуюших глаз (см. ниже) нет в Spot Mono и браузеру нужно фолбэчиться на какой-то японский системный шрифт, в котором они есть. Это рисково, плюс уже вызывает сложности с генерацией картинок.

Так что вместо этого:

```
・
KATAKANA MIDDLE DOT
Unicode: U+30FB, UTF-8: E3 83 BB
```

Я предлагаю вот это:

```
·
MIDDLE DOT
Unicode: U+00B7, UTF-8: C2 B7
```

И вот как оно выглядит: справа старые, слева новые.

https://user-images.githubusercontent.com/105274/137355380-b88cd853-2d14-4c0e-b4e3-ff24616c6dd0.mov