### PR TITLE
Правит стили контента

### DIFF
--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -23,7 +23,9 @@
             url=practiceAuthor.data.url
           ) }}
         </h3>
-        {{ practice.templateContent | safe }}
+        <div class="content">
+          {{ practice.templateContent | safe }}
+        </div>
       </article>
     {% endfor %}
 

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -13,27 +13,29 @@
   margin-bottom: 0;
 }
 
-.content > p {
+.content > p,
+.content > ul,
+.content > ol {
   margin-top: 10px;
   margin-bottom: 10px;
 }
 
-.content img,
-.content video,
-.content audio {
+.content > img,
+.content > video,
+.content > audio {
   display: block;
   max-width: 100%;
   height: auto;
 }
 
-.content iframe {
+.content > iframe {
   display: block;
   width: 100%;
   border: 0;
   background-color: #fff;
 }
 
-.content blockquote {
+.content > blockquote {
   margin-left: 0;
   position: relative;
   z-index: 0;
@@ -42,7 +44,7 @@
   border-radius: 0 6px 6px 0;
 }
 
-.content blockquote::before {
+.content > blockquote::before {
   content: '';
   opacity:
     calc(
@@ -54,7 +56,7 @@
   background-color: var(--accent-color);
 }
 
-.content blockquote::after {
+.content > blockquote::after {
   content: '';
   position: absolute;
   top: 0;
@@ -64,39 +66,14 @@
   background-color: var(--accent-color);
 }
 
-.content table {
-  border-collapse: collapse;
-}
-
-.content table th,
-.content table td {
-  text-align: start;
-  padding: 0.25em 0.5em;
-  border: 1px solid var(--color-fade);
-}
-
-.content table thead th {
-  position: relative;
-  z-index: 0;
-}
-
-.content table thead th::before {
-  content: '';
-  opacity: 0.6;
-  position: absolute;
-  z-index: -1;
-  inset: 0;
-  background-color: var(--color-fade);
-}
-
-.content img,
-.content video,
-.content audio,
-.content iframe,
-.content details,
-.content blockquote,
-.content table,
-.content .callout {
+.content > img,
+.content > video,
+.content > audio,
+.content > iframe,
+.content > details,
+.content > blockquote,
+.content > table,
+.content > .callout {
   margin-block: var(--offset);
 }
 
@@ -105,7 +82,7 @@
 }
 
 @media (max-height: 640px) {
-  .content iframe {
+  .content > iframe {
     max-height: calc(100vh - var(--header-height, 0) * 1px - 3em);
   }
 }

--- a/src/styles/blocks/table-wrapper.css
+++ b/src/styles/blocks/table-wrapper.css
@@ -1,3 +1,28 @@
 .table-wrapper {
   overflow: auto;
 }
+
+.table-wrapper > table {
+  border-collapse: collapse;
+}
+
+.table-wrapper > table th,
+.table-wrapper > table td {
+  text-align: start;
+  padding: 0.25em 0.5em;
+  border: 1px solid var(--color-fade);
+}
+
+.table-wrapper > table thead th {
+  position: relative;
+  z-index: 0;
+}
+
+.table-wrapper > table thead th::before {
+  content: '';
+  opacity: 0.6;
+  position: absolute;
+  z-index: -1;
+  inset: 0;
+  background-color: var(--color-fade);
+}


### PR DESCRIPTION
- Уточняет стили селекторов для контента
- Переносит стили таблиц в файл _table-wrapper.css_
- Оборачивает контент практик в блок с классом `content` (Fix: #585)