### PR TITLE
Правит блоки кода внутри callout

### DIFF
--- a/src/styles/blocks/callout.css
+++ b/src/styles/blocks/callout.css
@@ -1,5 +1,6 @@
 .callout {
   --padding: 10px;
+  --code-lines-background: var(--color-fade);
   display: flex;
   align-items: baseline;
   gap: 10px;
@@ -20,6 +21,14 @@
 
 .callout__content > * {
   max-width: 100%;
+}
+
+.callout__content > *:first-child {
+  margin-top: 0;
+}
+
+.callout__content > *:last-child {
+  margin-bottom: 0;
 }
 
 .callout__content .code {

--- a/src/styles/blocks/code-block.css
+++ b/src/styles/blocks/code-block.css
@@ -1,5 +1,6 @@
+/* вынесено в root, чтобы задать один экземпляр переменной, а не создавать несколько для каждого узла `code-block` */
 :root {
-  --number-lightness: calc(var(--is-dark-theme-on) * 60% + var(--is-light-theme-on) * 34%);
+  --code-lines-lightness: calc(var(--is-dark-theme-on) * 60% + var(--is-light-theme-on) * 34%);
 }
 
 .code-block {
@@ -30,8 +31,8 @@
   padding-right: 20px;
   font: inherit;
   text-align: end;
-  background-color: hsl(var(--color-base-background) / 0.92);
-  color: hsl(0 0% var(--number-lightness));
+  background-color: var(--code-lines-background, hsl(var(--color-base-background) / 0.92));
+  color: hsl(0 0% var(--code-lines-lightness));
 }
 
 .code-block__line {


### PR DESCRIPTION
- Задаёт переменную для задания фона номеров строк. #591
- Обнуляет отступы первого и последнего элемента внутри callout

Было

![image](https://user-images.githubusercontent.com/105274/137459380-f496e679-b6fc-47d6-b8d0-8db3e88f9a4e.png)

Стало

<img width="855" alt="image" src="https://user-images.githubusercontent.com/105274/137459437-fc981163-6611-4c72-a444-91374bd5fa30.png">
