### PR TITLE
Добавляет принудительный перенос для элементов `.code`

### DIFF
--- a/src/styles/blocks/code.css
+++ b/src/styles/blocks/code.css
@@ -1,5 +1,6 @@
 .code {
   padding: 0.025em 0.35em;
+  overflow-wrap: break-word;
   font-size: var(--font-size-m);
   line-height: var(--font-line-height-m);
   font-family: var(--font-family);


### PR DESCRIPTION
Например, на странице https://doka.guide/html/link/

![image](https://user-images.githubusercontent.com/6412192/137453179-cbc309a7-0ad9-4534-b8a1-da4416446937.png)
