### PR TITLE
Правки CSS-каскада для блока с авторами

### DIFF
--- a/src/styles/blocks/article.css
+++ b/src/styles/blocks/article.css
@@ -136,6 +136,52 @@
   margin-left: 0;
 }
 
+@media not all and (min-width: 1024px) {
+  .article {}
+
+  .article__layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .article__aside {
+    display: contents;
+  }
+
+  .article__nav {}
+
+  .article__meta {
+    order: 1;
+    display: grid;
+    align-items: start;
+    grid-template-columns: 1fr auto;
+  }
+
+  .article__persons {
+    margin-right: 2em;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .article__edit-button {
+    align-self: start;
+    grid-row-end: span 2;
+  }
+
+  .article__update-date {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  .article__content {
+    display: contents;
+  }
+
+  .article__content-inner {
+    padding: inherit;
+  }
+}
+
 @media not all and (min-width: 768px) {
   .article__meta {
     display: block;
@@ -236,52 +282,5 @@
   .article__persons {
     padding-top: 30px;
     padding-bottom: 30px;
-  }
-}
-
-@media not all and (min-width: 1024px) {
-  .article {}
-
-  .article__layout {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .article__aside {
-    display: contents;
-  }
-
-  .article__nav {}
-
-  .article__meta {
-    order: 1;
-    padding: inherit;
-    display: grid;
-    align-items: start;
-    grid-template-columns: 1fr auto;
-  }
-
-  .article__persons {
-    margin-right: 2em;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-
-  .article__edit-button {
-    align-self: start;
-    grid-row-end: span 2;
-  }
-
-  .article__update-date {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-
-  .article__content {
-    display: contents;
-  }
-
-  .article__content-inner {
-    padding: inherit;
   }
 }


### PR DESCRIPTION
Из-за merge блоков с media-выражениями поехала вёрстка для авторов:
![image](https://user-images.githubusercontent.com/6412192/137495275-0b3f9d60-e6da-4d73-9c60-f021f074abf6.png)
