### PR TITLE
Убирает глобальный sandbox

### DIFF
--- a/src/transforms/iframe-attr-transform.js
+++ b/src/transforms/iframe-attr-transform.js
@@ -1,10 +1,4 @@
-const iframePolicies = [
-  'allow-scripts',
-  'allow-forms',
-]
-
 const attrs = {
-  sandbox: iframePolicies.join(' '),
   loading: 'lazy',
 }
 


### PR DESCRIPTION
Иначе всё больше проблем: фрейм во фрейме, формы, алерты.

Дополнительно нужно добавить `sandbox` руками в некоторые контентные статьи:

- [ ] [Element.focus()](https://doka.guide/js/element-focus/)

Куда-то ещё?