### PR TITLE
Исправляет вспышку при переключении темы

### DIFF
--- a/src/scripts/modules/theme-toggle.js
+++ b/src/scripts/modules/theme-toggle.js
@@ -44,9 +44,29 @@ function setCurrentTheme(theme) {
 }
 
 function toggleTheme(event) {
+  let browserTheme
+  const currentTheme = getCurrentTheme();
   const newTheme = event.target?.value
 
+  if(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches){
+    browserTheme = 'dark'
+  } else {
+    browserTheme = 'light'
+  }
+
   if (!newTheme) {
+    return
+  }
+
+  // Не переключаем тему по клику на Авто, если они совпадют
+  if(newTheme === 'auto' && (currentTheme === browserTheme)) {
+    setCurrentTheme(newTheme)
+    return
+  }
+
+  // Не переключаем тему по клику на !Авто, если они совпадют
+  if(currentTheme === 'auto' && browserTheme === newTheme) {
+    setCurrentTheme(newTheme)
     return
   }
 


### PR DESCRIPTION
Fix #412 

В превью Safari, потому как на нем эта проблема выражена сильнее и флеш по каждому клику, в Chrome такая же беда, но проявляется реже.

Было:

https://user-images.githubusercontent.com/19520678/138166857-d0cbbd33-8f16-484e-aca2-e0b73467d4ae.mov

Стало:

https://user-images.githubusercontent.com/19520678/138167085-850464b9-57c1-4de4-b0de-428bfe5bc738.mov

`console.log` убран.