### PR TITLE
Исправляет make-links.js

### DIFF
--- a/make-links.js
+++ b/make-links.js
@@ -31,7 +31,11 @@ const createLinks = (contentPath) => {
   SYMLINKS_DEST.forEach((dest, i) => {
     const source = path.join(contentPath, contentRepFolders[i])
     console.log(`${dest} → ${source}`)
-    fs.symlinkSync(source, dest)
+    try {
+      fs.symlinkSync(source, dest);
+    } catch (e) {
+      fs.symlinkSync(source, dest, 'junction');
+    }
   })
 
   console.log('✅ Готово')

--- a/src/styles/blocks/nav-list.css
+++ b/src/styles/blocks/nav-list.css
@@ -16,7 +16,7 @@
 }
 
 .nav-list__link {
-  display: inline-block;
+  display: inline-flex;
   vertical-align: top;
   padding-top: var(--block-padding);
   padding-bottom: var(--block-padding);
@@ -24,6 +24,7 @@
   padding-right: 10px;
   text-decoration: none;
   color: inherit;
+  width: calc(100% - 20px);
 }
 
 .nav-list__link::after {


### PR DESCRIPTION
Fix #675 На windows без третьего параметра скрипт завершается с ошибкой.
[Документация](https://nodejs.org/api/fs.html#fssymlinktarget-path-type-callback)