### PR TITLE
Исправляет переключение цветовой схемы

### DIFF
--- a/src/scripts/modules/theme-toggle.js
+++ b/src/scripts/modules/theme-toggle.js
@@ -36,11 +36,7 @@ function getCurrentTheme() {
 }
 
 function setCurrentTheme(theme) {
-  if (theme === THEMES.AUTO) {
-    store.removeItem(STORAGE_KEY)
-  } else {
-    store.setItem(STORAGE_KEY, theme)
-  }
+  store.setItem(STORAGE_KEY, theme)
 }
 
 function toggleTheme(event) {


### PR DESCRIPTION
Шаги для воспроизведения проблемы:
1. Перейти на сайт Доки и прокрутить экран до переключателя цветовой схемы. Условие: цветовая схема на данном этапе - "Авто". Пусть вкладка в браузере, в которой открыт этот сайт, будет называться "Вкладка №1".
2. Выбрать цветовую схему "Тёмная" (если цветовая схема ОС светлая, и наоборот).
3. Продублировать вкладку с сайтом Доки в браузере (пусть продублированная вкладка будет называться "Вкладка №2"). Она будет иметь цветовую схему, выбранную на предыдущем шаге.
4. Во вкладке №1 выбрать цветовую схему "Авто". Цветовая схема текущей вкладки становится такой, которая была до переключения.
5. Проверить цветовую схему во вкладке № 2.

**Ожидание**: цветовая схема во вкладке № 2 такая же, как и во вкладке № 1.
**Реальность**: цветовая схема во кладке № 2 такая же, как и на шаге 3.

Данный PR исправляет эту проблему.

P.S.:
1. по какой-то причине, при локальной разработке эта проблема воспроизводится через раз, хотя на сайте она воспроизводится стабильно. Возможно, что-то кэшируется, да так, что даже hard reload не помогает.
2. Возможно, можно убрать `applyTheme(newTheme)` из `toggleTheme`, поскольку в этой функции устанавливается значение в `localStorage`, а в обработчике событий на это изменение (`window.addEventListener('storage')`) уже есть `applyTheme(newTheme)`, но я не уверен, что знаю все крайние случаи, чтобы делать такое изменение.
3. Думаю, @pepelsbey будет интересен этот PR. Насколько я понимаю, текущая реализация основана на (или каким-то другим образом связана с) видео ["Переключатель 🌓 цветовой схемы"](https://www.youtube.com/watch?v=8LFbS78a4Rw). По всей видимости, эта проблема присутствует и там.