### PR TITLE
Отключает режим синхронизации BrowserSync

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,6 +32,7 @@ module.exports = function(config) {
       'src/styles/**/*.*',
       'src/scripts/**/*.*'
     ],
+    ghostMode: false,
   })
 
   // Add all Tags


### PR DESCRIPTION
Из-за него возникают неочевидные баги, например, [такие](https://github.com/doka-guide/platform/pull/679)