### PR TITLE
Добавляет alt к изображениям для featured articles на главной

### DIFF
--- a/src/includes/blocks/featured-article.njk
+++ b/src/includes/blocks/featured-article.njk
@@ -4,7 +4,7 @@
   <article class="featured-article" style="--accent-color: var(--color-{{ article.section }})">
     {% if hasImage %}
       <picture class="featured-article__image-wrapper">
-        <img class="featured-article__image" src="{{ article.imageLink }}" loading="lazy" alt="">
+        <img class="featured-article__image" src="{{ article.imageLink }}" loading="lazy" alt="{{ article.cover.alt }}">
       </picture>
     {% endif %}
     <h3 class="featured-article__title">


### PR DESCRIPTION
Внутри фичер статей альт есть, а на главной про него забыли  🌚

<img width="967" alt="image" src="https://user-images.githubusercontent.com/1949927/138964878-a982ad0a-4f59-4f5f-b208-51f63746a283.png">
