### PR TITLE
Правит ошибки и предупреждения Google для метаданных статьи

### DIFF
--- a/src/includes/blocks/article-image.njk
+++ b/src/includes/blocks/article-image.njk
@@ -5,7 +5,7 @@
       {% if cover.mobile %}
         <source srcset="{{ cover.mobile }}" media="(max-width: 425px)" width="1080" height="1080">
       {% endif %}
-      <img class="article-image__content" src="{{ cover.desktop }}" alt="{{ cover.alt }}" width="1920" height="1080">
+      <img class="article-image__content" src="{{ cover.desktop }}" alt="{{ cover.alt }}" width="1920" height="1080" itemprop="image">
     </picture>
     {% if (authors and authors.length > 0) %}
       <div class="article-image__author">

--- a/src/includes/contributors.njk
+++ b/src/includes/contributors.njk
@@ -1,12 +1,14 @@
 {% macro person(name, url) %}
   {% if url %}
-    <a class="persons-list__name link" href="{{ url }}">{{ name }}</a>
+    <a class="persons-list__name link" href="{{ url }}" itemprop="url">
+      <span itemprop="name">{{ name }}</span>
+    </a>
   {% else %}
-    <span class="persons-list__name">{{ name }}</span>
+    <span class="persons-list__name" itemprop="name">{{ name }}</span>
   {% endif %}
 {% endmacro %}
 
-{% macro personsList(list, maxPersons = 3) %}
+{% macro personsList(list, personType, maxPersons = 3) %}
   {% set totalPersonsCount = list.length %}
   {% set extraPersonsCount = totalPersonsCount - maxPersons %}
   {% set divider = "," %}
@@ -15,7 +17,11 @@
     <ul class="persons-list__items base-list">
       {% for personItem in list %}
         {% set isHidden = loop.index > maxPersons %}
-        <li class="persons-list__item" {% if isHidden %}hidden{% endif %}>
+        <li
+          class="persons-list__item" {% if isHidden %}hidden{% endif %}
+          itemscope itemtype="https://schema.org/Person"
+          {% if personType %}itemprop="{{ personType }}"{% endif %}
+        >
           {{ person(name=personItem.data.name, url=personItem.data.url) }}
           {% if not loop.last %}
             {{ divider }}
@@ -34,20 +40,20 @@
 <dl class="contributors">
   <div class="contributors__item">
     <dt class="contributors__key">Авторы:</dt>
-    <dd class="contributors__value">{{ personsList(list=populatedAuthors) }}</dd>
+    <dd class="contributors__value">{{ personsList(list=populatedAuthors, personType="author") }}</dd>
   </div>
 
   {% if populatedContributors.length > 0 %}
     <div class="contributors__item">
       <dt class="contributors__key">Контрибьюторы:</dt>
-      <dd class="contributors__value">{{ personsList(list=populatedContributors) }}</dd>
+      <dd class="contributors__value">{{ personsList(list=populatedContributors, personType="contributor") }}</dd>
     </div>
   {% endif %}
 
   {% if populatedEditors.length > 0 %}
     <div class="contributors__item">
       <dt class="contributors__key">Редакторы:</dt>
-      <dd class="contributors__value">{{ personsList(list=populatedEditors) }}</dd>
+      <dd class="contributors__value">{{ personsList(list=populatedEditors, personType="editor") }}</dd>
     </div>
   {% endif %}
 </dl>

--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -1,6 +1,9 @@
 {% macro authorsList(list) %}[{% for personItem in list %}{
   "@type": "Person",
   "name": "{{ personItem.data.name }}"
+  {% if personItem.data.url %}
+    ,"url": "{{ personItem.data.url }}"
+  {% endif %}
 }{{ '' if loop.last else ',' }}{% endfor %}]{% endmacro %}
 
 <!-- 1. Title and Primary Meta -->
@@ -106,9 +109,16 @@
         "@type": "WebPage",
         "@id": "{{ fullPageUrl }}"
       },
-      "headline": "{{ fullPageUrl }}",
-      "datePublished": "{{ createdAt }}",
-      "dateModified": "{{ updatedAt }}",
+      "headline": "{{ socialTitle }}",
+      {% if cover %}
+      "image": [
+        "{{ fullPageUrl }}{{ cover.desktop if cover.desktop }}"
+        {% if cover.mobile %},{% endif %}
+        "{{ fullPageUrl }}{{ cover.mobile if cover.mobile }}"
+      ],
+      {% endif %}
+      "datePublished": "{{ createdAt.toISOString() if createdAt }}",
+      "dateModified": "{{ updatedAt.toISOString() if updatedAt }}",
       "author": {{ authorsList(list=populatedAuthors) }},
       "publisher": {
         "@type": "Organization",
@@ -119,7 +129,7 @@
         }
       },
       "description": "{{ doc.data.description }}",
-      "url": "{{ fullPageUrl }}",
+      "url": "{{ fullPageUrl }}"
     }
   </script>
   <meta property="article:section" content="Technology">

--- a/src/views/doc.njk
+++ b/src/views/doc.njk
@@ -29,7 +29,7 @@
             <span class="article__category-divider" aria-hidden="true">/</span>
           </p>
 
-          <h1 class="article__title">
+          <h1 class="article__title" itemprop="headline">
             {{ title | titleMarkdown | safe }}
           </h1>
 


### PR DESCRIPTION
Fix: #672

- Удаляет лишниюю запятую в ld+json
- Добавляет url для авторов в ld+json
- Добавляет изображения в ld+json
- Приводит даты к ISO-формату в ld+json
- Задаёт корректный `headline` в ld+json (был не заголовок, а url)
- Расставляет sсhema-атрибуты в статье