### PR TITLE
Правка пересечения стилей prism при рендере блоков кода внутри markdown-блоков с кодом

### DIFF
--- a/src/styles/blocks/block-code.css
+++ b/src/styles/blocks/block-code.css
@@ -1,9 +1,9 @@
-/* вынесено в root, чтобы задать один экземпляр переменной, а не создавать несколько для каждого узла `code-block` */
+/* вынесено в root, чтобы задать один экземпляр переменной, а не создавать несколько для каждого узла `block-code` */
 :root {
   --code-lines-lightness: calc(var(--is-dark-theme-on) * 60% + var(--is-light-theme-on) * 34%);
 }
 
-.code-block {
+.block-code {
   --line-height: calc(24 / 18);
   margin-top: 10px;
   margin-bottom: 20px;
@@ -22,7 +22,7 @@
   font-family: var(--font-family, monospace);
 }
 
-.code-block__lines {
+.block-code__lines {
   grid-area: lines;
   position: sticky;
   left: 0;
@@ -35,56 +35,56 @@
   color: hsl(0 0% var(--code-lines-lightness));
 }
 
-.code-block__line {
+.block-code__line {
   counter-increment: line-count;
   position: relative;
   display: block;
   min-height: calc(var(--line-height) * 1em);
 }
 
-.code-block__line::before {
+.block-code__line::before {
   content: counter(line-count);
   display: block;
 }
 
-.code-block__original,
-.code-block__highlight {
+.block-code__original,
+.block-code__highlight {
   grid-area: code;
   font: inherit;
 }
 
-.code-block__original {
+.block-code__original {
   visibility: hidden;
   user-select: none;
 }
 
-.code-block__original-line {
+.block-code__original-line {
   white-space: pre;
   display: block;
   min-height: calc(var(--line-height) * 1em);
   font: inherit;
 }
 
-.code-block__highlight {
+.block-code__highlight {
   white-space: pre;
 }
 
 @media (min-width: 768px) {
-  .code-block {
+  .block-code {
     margin-top: 20px;
     margin-bottom: 20px;
   }
 }
 
 @media (min-width: 1024px) {
-  .code-block {
+  .block-code {
     margin-top: 20px;
     margin-bottom: 60px;
   }
 }
 
 @media (min-width: 1680px) {
-  .code-block {
+  .block-code {
     margin-top: 32px;
     margin-bottom: 50px;
   }

--- a/src/styles/blocks/callout.css
+++ b/src/styles/blocks/callout.css
@@ -16,6 +16,7 @@
 }
 
 .callout__content {
+  --background-code-color: hsl(0 0% calc(var(--is-light-theme-on) * 100%));
   flex: 1 1 auto;
 }
 
@@ -29,10 +30,6 @@
 
 .callout__content > *:last-child {
   margin-bottom: 0;
-}
-
-.callout__content .code {
-  --background-color: hsl(0 0% calc(var(--is-light-theme-on) * 100%));
 }
 
 @media (min-width: 768px) {

--- a/src/styles/blocks/inline-code.css
+++ b/src/styles/blocks/inline-code.css
@@ -1,5 +1,4 @@
-.code {
-  --background-color: var(--color-fade);
+.inline-code {
   padding: 0.025em 0.35em;
   overflow-wrap: break-word;
   font-size: var(--font-size-m);
@@ -7,5 +6,5 @@
   font-family: var(--font-family);
   letter-spacing: var(--letter-spacing);
   border-radius: 2em;
-  background-color: var(--background-color);
+  background-color: var(--background-code-color, var(--color-fade));
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -10,7 +10,7 @@
 @import 'blocks/container.css';
 @import 'blocks/font-theme.css';
 @import 'blocks/link.css';
-@import 'blocks/code.css';
+@import 'blocks/inline-code.css';
 @import 'blocks/button.css';
 @import 'blocks/base.css';
 @import 'blocks/logo.css';
@@ -36,7 +36,7 @@
 @import 'blocks/doc.css';
 @import 'blocks/persons-list.css';
 @import 'blocks/toc.css';
-@import 'blocks/code-block.css';
+@import 'blocks/block-code.css';
 @import 'blocks/details.css';
 @import 'blocks/format-block.css';
 @import 'blocks/vote.css';

--- a/src/styles/index.sc.css
+++ b/src/styles/index.sc.css
@@ -9,7 +9,7 @@
 @import 'blocks/container.css';
 @import 'blocks/font-theme.css';
 @import 'blocks/link.css';
-@import 'blocks/code.css';
+@import 'blocks/inline-code.css';
 @import 'blocks/button.css';
 @import 'blocks/base.css';
 @import 'blocks/logo.css';
@@ -35,7 +35,7 @@
 @import 'blocks/doc.css';
 @import 'blocks/persons-list.css';
 @import 'blocks/toc.css';
-@import 'blocks/code-block.css';
+@import 'blocks/block-code.css';
 @import 'blocks/format-block.css';
 @import 'blocks/vote.css';
 @import 'blocks/feedback-form.css';

--- a/src/transforms/code-transform.js
+++ b/src/transforms/code-transform.js
@@ -12,7 +12,7 @@ const LANG_ALIASES= {
 }
 
 function renderOriginalLine(line) {
-  return `<span class="code-block__original-line">${escape(line)}</span>`
+  return `<span class="block-code__original-line">${escape(line)}</span>`
 }
 
 function highlightCode(source, language) {
@@ -55,18 +55,18 @@ module.exports = function(window) {
       const originalSplittedContent = lines.join('')
 
       const linesBlock = window.document.createElement('span')
-      linesBlock.classList.add('code-block__lines')
+      linesBlock.classList.add('block-code__lines')
       linesBlock.innerHTML = Array.from(
         { length: lines.length },
-        () => `<span class="code-block__line"></span>`
+        () => `<span class="block-code__line"></span>`
       ).join('')
 
-      preElement.classList.add('code-block', 'font-theme', 'font-theme--code')
+      preElement.classList.add('block-code', 'font-theme', 'font-theme--code')
       preElement.setAttribute('tabindex', 0)
       preElement.innerHTML = `
-      ${linesBlock.outerHTML}
-        <span class="code-block__original">${originalSplittedContent}</span>
-        <code class="code-block__highlight">${highlightedContent}</code>
+        ${linesBlock.outerHTML}
+        <span class="block-code__original">${originalSplittedContent}</span>
+        <code class="block-code__highlight">${highlightedContent}</code>
       `
     })
 
@@ -80,7 +80,7 @@ module.exports = function(window) {
   articleContent
     ?.querySelectorAll('p code, ul code, ol code, table code')
     ?.forEach(codeElement => {
-      codeElement.classList.add('code', 'font-theme', 'font-theme--code')
+      codeElement.classList.add('inline-code', 'font-theme', 'font-theme--code')
     })
 
   // добавление классов на блоки `code` внутри заголовков


### PR DESCRIPTION
Fix: #723

Prism делает подсветку блоков кода внутри markdown, то есть, если в статье будет такой блок кода:

`````
````md
Пример кода на js:

```javascript
function add(x, y) {
  return x + y;
}
```
````
`````

то он выполнит токенизацию для js-блока.

Проблема просто в пересечении стилей - на вложенных блоках prism добавляет классы `code`, `code-snippet`, `code-block`. Поэтому сделал переименование CSS-классов.