### PR TITLE
Превентит Esc, чтобы не выходить из фулскрина

### DIFF
--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -140,6 +140,7 @@ function init() {
 
     document.addEventListener('keyup', (event) => {
       if (event.code === 'Escape') {
+        event.preventDefault()
         searchForm.reset()
       }
 


### PR DESCRIPTION
В браузерах Safari и Firefox на macOS нажатие на Esc выводит браузер из полноэкранного режима.

Без `preventDefault()` меню не закрыть без выхода из фулскрина, что очень мешает.