### PR TITLE
Удаляет обработку старой версии callout.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,7 +1,6 @@
 const { slugify } = require('transliteration')
 const htmlnano = require('htmlnano')
 const markdownIt = require('markdown-it')
-const markdownItContainer = require('markdown-it-container')
 const { parseHTML } = require('linkedom')
 const { isProdEnv } = require('./config/env')
 const { mainSections } = require('./config/constants.js')
@@ -109,30 +108,6 @@ module.exports = function(config) {
         : `<pre>${content}</pre>`
     }
   })
-
-  {
-    const calloutElementRegexp = /^callout\s+(.*)$/
-
-    markdownLibrary.use(markdownItContainer, 'callout', {
-      validate(params) {
-        return params.trim().match(calloutElementRegexp)
-      },
-
-      render(tokens, idx) {
-        const { info, nesting } = tokens[idx]
-        const matches = info.trim().match(calloutElementRegexp)
-
-        if (nesting === 1) {
-          const icon = markdownLibrary.utils.escapeHtml(matches[1])
-          return `<aside class="callout">
-              ${icon ? `<div class="callout__icon">${icon}</div>` : ''}
-              <div class="callout__content">`
-        }
-
-        return `</div></aside>`
-      },
-    })
-  }
 
   config.setLibrary('md', markdownLibrary)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "linkedom": "^0.13.0",
         "lint-staged": "^11.2.3",
         "markdown-it": "^12.2.0",
-        "markdown-it-container": "^3.0.0",
         "postcss": "^8.3.9",
         "postcss-csso": "^5.0.1",
         "postcss-import": "^14.0.2",
@@ -8160,12 +8159,6 @@
       "bin": {
         "markdown-it": "bin/markdown-it.js"
       }
-    },
-    "node_modules/markdown-it-container": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
-      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw==",
-      "dev": true
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
@@ -21404,12 +21397,6 @@
           "dev": true
         }
       }
-    },
-    "markdown-it-container": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-3.0.0.tgz",
-      "integrity": "sha512-y6oKTq4BB9OQuY/KLfk/O3ysFhB3IMYoIWhGJEidXt1NQFocFK2sA2t0NYZAMyMShAGL6x5OPIbrmXPIqaN9rw==",
-      "dev": true
     },
     "matchdep": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "linkedom": "^0.13.0",
     "lint-staged": "^11.2.3",
     "markdown-it": "^12.2.0",
-    "markdown-it-container": "^3.0.0",
     "postcss": "^8.3.9",
     "postcss-csso": "^5.0.1",
     "postcss-import": "^14.0.2",


### PR DESCRIPTION
Старая версия работала путём расширения синтаксиса makdown через пакет markdown-it-container.