### PR TITLE
Правит баг с некорректным выставлением hash в safari на странице индексов

### DIFF
--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -39,7 +39,7 @@
             <ul class="index-group-list base-list">
               {% for group in sectionIndex.data.groups %}
                 <li class="index-group-list__item">
-                  <a class="index-group-list__link link" href="/{{ category }}#{{ group.name | slugify }}">
+                  <a class="index-group-list__link link" href="/{{ category }}/#{{ group.name | slugify }}">
                     {{ group.name | descriptionMarkdown | safe }}
                   </a>
                 </li>


### PR DESCRIPTION
Пример: при переходе с главной страницы на группу индекса `https://doka.guide/html#osnovy` Safari добавляет `/` перед `#` - `https://doka.guide/html/#osnovy`. Затем, какую бы группу на главной ни выбрали, например, `https://doka.guide/html#semantika`, Safari будет перенаправлять на снова `https://doka.guide/html/#osnovy`.

Решение: явно добавить слеши `/`.