### PR TITLE
Рефакторит страницу поиска для преобразования состояния фильтров в search params

### DIFF
--- a/src/includes/blocks/search-category.njk
+++ b/src/includes/blocks/search-category.njk
@@ -4,7 +4,7 @@
 
   {% for category in collections.articleIndexes %}
     <label class="search-category__item tag-filter" style="--accent-color: var(--color-{{ category.fileSlug }})">
-      <input class="tag-filter__control" type="radio" name="search-category" value="category:{{ category.fileSlug }}" form="search-form">
+      <input class="tag-filter__control" type="checkbox" name="category" value="{{ category.fileSlug }}" form="search-form">
       <span class="tag-filter__text">
         {{ category.data.name }}
       </span>

--- a/src/includes/blocks/search-tags.njk
+++ b/src/includes/blocks/search-tags.njk
@@ -4,15 +4,15 @@
 
   <div class="search-tag__switch switch">
     <label class="switch__item">
-      <input class="switch__input" type="radio" name="tag" value="" form="search-form" autocomplete="off" checked>
+      <input class="switch__input" type="radio" name="tag" value="" form="search-form" checked>
       <span class="switch__label">Все</span>
     </label>
     <label class="switch__item">
-      <input class="switch__input" type="radio" name="tag" value="article" form="search-form" autocomplete="off">
+      <input class="switch__input" type="radio" name="tag" value="article" form="search-form">
       <span class="switch__label">Статьи</span>
     </label>
     <label class="switch__item">
-      <input class="switch__input" type="radio" name="tag" value="doka" form="search-form" autocomplete="off">
+      <input class="switch__input" type="radio" name="tag" value="doka" form="search-form">
       <span class="switch__label">Справочник</span>
     </label>
   </div>

--- a/src/includes/blocks/search-tags.njk
+++ b/src/includes/blocks/search-tags.njk
@@ -4,15 +4,15 @@
 
   <div class="search-tag__switch switch">
     <label class="switch__item">
-      <input class="switch__input" type="radio" name="search-tag" value="" form="search-form" autocomplete="off" checked>
+      <input class="switch__input" type="radio" name="tag" value="" form="search-form" autocomplete="off" checked>
       <span class="switch__label">Все</span>
     </label>
     <label class="switch__item">
-      <input class="switch__input" type="radio" name="search-tag" value="tags:article" form="search-form" autocomplete="off">
+      <input class="switch__input" type="radio" name="tag" value="article" form="search-form" autocomplete="off">
       <span class="switch__label">Статьи</span>
     </label>
     <label class="switch__item">
-      <input class="switch__input" type="radio" name="search-tag" value="tags:doka" form="search-form" autocomplete="off">
+      <input class="switch__input" type="radio" name="tag" value="doka" form="search-form" autocomplete="off">
       <span class="switch__label">Справочник</span>
     </label>
   </div>

--- a/src/includes/blocks/search.njk
+++ b/src/includes/blocks/search.njk
@@ -1,6 +1,6 @@
 <form class="header__search search font-theme font-theme--code" method="get" name="search-form" action="/search/" id="search-form">
   <div class="search__control">
-    <input class="search__input" type="text" name="q" placeholder="Поиск" autocomplete="off">
+    <input class="search__input" type="text" name="query" placeholder="Поиск" autocomplete="off">
 
     <kbd class="hotkey search__key search__key--activate">/</kbd>
     <kbd class="hotkey search__key search__key--enter">↲</kbd>

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -1,29 +1,100 @@
 import { escape } from '/html-escaper/esm/index.js'
 import debounce from '../libs/debounce.js'
 import searchClient from '../core/search-api-client.js'
+import BaseComponent from '../core/base-component.js'
 import { MIN_SEARCH_SYMBOLS, SYMBOL_LIMIT, DELIMITER, SEARCHABLE_SHORT_WORDS, processHits } from '../core/search-commons.js'
 
-function init() {
-  const SEARCH_FORM_SELECTOR = '.search'
-  const SEARCH_FIELD_SELECTOR = '.search__input'
-  const SEARCH_HITS_SELECTOR = '.search__output'
-  const SEARCH_TAG_SELECTOR = '.search-tag'
-  const SEARCH_CATEGORY_SELECTOR = '.search-category'
+class Filter extends BaseComponent {
+  constructor({ form }) {
+    super()
 
-  let facetTagList = []
-  let facetCategoryList = []
-  let facetFilterList = []
+    this.refs = { form }
 
-  const searchForm = document.querySelector(SEARCH_FORM_SELECTOR)
-  const searchField = document.querySelector(SEARCH_FIELD_SELECTOR)
-  const searchHits = document.querySelector(SEARCH_HITS_SELECTOR)
+    Array.from(form.elements)
+      .filter(element => !!element.name)
+      .forEach(element => {
+        element.addEventListener('input', this)
+      })
 
-  function markQuery(text, query) {
-    const searchRegEx = new RegExp(query, 'gi')
-    return text.replace(searchRegEx, match => templates.mark(match))
+    form.addEventListener('reset', () => {
+      // событие reset срабатывает перед тем, как поля очистятся
+      setTimeout(() => {
+        this.emit('reset', this.state)
+      })
+    })
+
+    queueMicrotask(() => {
+      this.emit('change.query', this.state)
+    })
   }
 
-  function adjustTextMatch(text, index, query, limit) {
+  get state() {
+    const newFormData = new FormData()
+    const originalFormData = new FormData(this.refs.form)
+
+    for (const [name, value] of originalFormData) {
+      if (value) {
+        newFormData.append(name, value)
+      }
+    }
+
+    return newFormData
+  }
+
+  set state(newState) {
+    const { form } = this.refs
+
+    for (const [name, value] of newState.entries()) {
+      switch (name) {
+        case 'query': {
+          form.elements[name].value = value
+          break
+        }
+
+        case 'tag':
+        case 'category': {
+          const elements = Array.from(form.elements[name])
+          const element = elements.find(element => element.value === value)
+          element.checked = true
+          break
+        }
+      }
+    }
+  }
+
+  handleEvent(event) {
+    const { name } = event.target
+
+    switch (name) {
+      case 'query': {
+        this.emit('change.query', this.state)
+        break
+      }
+
+      default: {
+        this.emit('change.filter', this.state)
+      }
+    }
+
+    this.emit('change', this.state)
+  }
+}
+
+class SearchResultOutput extends BaseComponent {
+  static isPlaceholder(hitObject) {
+    return hitObject.tags.includes('placeholder')
+  }
+
+  static replaceBackticks(text, replaceTemplate) {
+    return text.replace(/`(.*?)`/g, replaceTemplate)
+  }
+
+  static markQuery(text, query) {
+    const searchRegEx = new RegExp(query, 'gi')
+    return text.replace(searchRegEx, match => SearchResultOutput.templates.mark(match))
+  }
+
+  static adjustTextMatch(text, index, query, limit) {
     if ((index - query.length / 2 > limit / 2) && (text.length - index + query.length / 2 <= limit / 2)) {
       return `${DELIMITER}${text.substring(index - limit / 2 - query.length / 2, text.length).trim()}`
     } else if ((index - query.length / 2 <= limit / 2) && (text.length - index + query.length / 2 > limit / 2)) {
@@ -33,19 +104,19 @@ function init() {
     }
   }
 
-  function adjustTextSize(text, query, limit) {
+  static adjustTextSize(text, query, limit) {
     if (text.length <= limit) {
       return text
     } else {
       const searchRegEx = new RegExp(query, 'gi')
       const result = text.matchAll(searchRegEx)
       if (result && result.length === 1) {
-          return adjustTextMatch(text, result.index, result[0], limit)
+          return SearchResultOutput.adjustTextMatch(text, result.index, result[0], limit)
       } else if (result && result.length > 1) {
-        let output = adjustTextMatch(text, result[0].index, result[0], limit)
+        let output = SearchResultOutput.adjustTextMatch(text, result[0].index, result[0], limit)
         for (let i = 1; i < result.length; i++) {
           const t = text.substring(result[i - 1].index, result[i - 1].index + limit + result[i].length)
-          output += `${DELIMITER}${adjustTextMatch(t, result[i].index, result[i], limit)}`
+          output += `${DELIMITER}${SearchResultOutput.adjustTextMatch(t, result[i].index, result[i], limit)}`
         }
         return output
       } else {
@@ -54,54 +125,156 @@ function init() {
     }
   }
 
-  function renderHits(hitObjectList, query, limit) {
-    if (!hitObjectList || hitObjectList.length === 0) {
-      return templates.emptyResults()
+  static get templates() {
+    return {
+      mark: (match) => `<mark class="search-hit__marked">${match}</mark>`,
+
+      hit: (hitObject, query, limit) => {
+        const editIcon = SearchResultOutput.isPlaceholder(hitObject)
+          ? '<span class="search-hit__edit font-theme font-theme--code" aria-hidden="true"></span>'
+          : ''
+        const title =
+        SearchResultOutput.replaceBackticks(
+          SearchResultOutput.markQuery(
+              escape(hitObject.title),
+              query
+            ),
+            '<code class="search-hit__link-code font-theme font-theme--code">$1</code>'
+          )
+        const summary =
+        SearchResultOutput.replaceBackticks(
+          SearchResultOutput.markQuery(
+              escape(SearchResultOutput.adjustTextSize(hitObject.summary, query, limit)),
+              query
+            ),
+            '<code class="search-hit__text-code font-theme font-theme--code">$1</code>'
+          )
+
+        return `
+          <article class="search-hit" style="--accent-color: var(--color-base-${hitObject.category})">
+            <h3 class="search-hit__title">
+              <a class="search-hit__link link" href="${hitObject.url}">
+                ${editIcon}${title}
+              </a>
+            </h3>
+            <div class="search-hit__summary">
+              ${summary}
+            </div>
+          </article>
+        `
+      },
+
+      hits: (list, query, limit) => `
+        <ol class="search-result-list base-list">
+          ${
+            list.map(hitObject => `
+              <li class="search-result-list__item">
+                ${SearchResultOutput.templates.hit(hitObject, query, limit)}
+              </li>
+            `)
+            .join('')
+          }
+        </ol>
+      `,
+
+      emptyResults: () => `
+        <div class="search-page__empty">Ничего не найдено</div>
+      `,
     }
-
-    return templates.hits(hitObjectList, query, limit)
   }
 
-  function updateFacet() {
-    facetFilterList = [facetTagList, facetCategoryList]
+  constructor({ element }) {
+    super()
+    this.refs = {
+      element
+    }
   }
 
-  function makeSearchEffect(queryText) {
+  renderHits(hitObjectList, queryText, SYMBOL_LIMIT) {
+    const { element } = this.refs
+
+    const result = (!hitObjectList || hitObjectList.length === 0)
+      ? SearchResultOutput.templates.emptyResults()
+      : SearchResultOutput.templates.hits(hitObjectList, queryText, SYMBOL_LIMIT)
+
+    element.innerHTML = result
+  }
+
+  clear() {
+    const { element } = this.refs
+    element.innerHTML = ''
+  }
+}
+
+function init() {
+  const SEARCH_FORM_SELECTOR = '.search'
+  const SEARCH_FIELD_SELECTOR = '.search__input'
+  const SEARCH_HITS_SELECTOR = '.search__output'
+
+  const searchForm = document.querySelector(SEARCH_FORM_SELECTOR)
+  const searchField = document.querySelector(SEARCH_FIELD_SELECTOR)
+  const searchHits = document.querySelector(SEARCH_HITS_SELECTOR)
+
+  const filter = new Filter({
+    form: searchForm
+  })
+  filter.state = new URLSearchParams(location.search)
+
+  const searchResultOutput = new SearchResultOutput({
+    element: searchHits
+  })
+
+  // преобразует состояние фильтров в понятный для Algolia формат
+  function prepareFilters(filtersState) {
+    const result = [
+      [...filtersState.getAll('category')].map(value => `category:${value}`),
+      [...filtersState.getAll('tag')].map(value => `tags:${value}`)
+    ]
+
+    return result
+  }
+
+  // сериализует состояние фильтров в формат Search Params
+  function filtersToSearchParams(filtersState, fallbackPath) {
+    let searchString = (new URLSearchParams(filtersState)).toString()
+    searchString = searchString ? ('?' + searchString) : fallbackPath
+    return searchString
+  }
+
+  function makeSearchEffect(queryText, filters) {
     if (queryText.length >= MIN_SEARCH_SYMBOLS || SEARCHABLE_SHORT_WORDS.has(queryText)) {
-      searchClient.search(queryText, { facetFilters: facetFilterList })
-        .then(function(searchObject) {
-          const processedHits = processHits(searchObject)
-          searchHits.innerHTML = renderHits(processedHits, queryText, SYMBOL_LIMIT)
-        })
-        .catch(error => {
-          console.error(error)
-        })
+      searchClient.search(queryText, {
+        facetFilters: filters
+      })
+      .then(function(searchObject) {
+        const processedHits = processHits(searchObject)
+        searchResultOutput.renderHits(processedHits, queryText, SYMBOL_LIMIT)
+      })
+      .catch(error => {
+        console.error(error)
+      })
     } else {
-      searchHits.innerHTML = ''
+      searchResultOutput.clear()
     }
   }
+
+  function onFilterChange(event) {
+    const state = event.detail
+    const queryText = state.get('query') || ''
+    const filters = prepareFilters(state)
+
+    makeSearchEffect(queryText, filters)
+  }
+
+  function transformFiltersToSearchParamsOnChange(event) {
+    const state = event.detail
+    const searchParams = filtersToSearchParams(state, location.pathname)
+    history.replaceState(null, null, searchParams)
+  }
+
+  const debouncedOnFilterChange = debounce(onFilterChange, 150)
 
   function assignSearchField() {
-    if (!searchField && !searchHits && !searchForm) {
-      return
-    }
-
-    const params = new URLSearchParams(window.location.search)
-    const queryText = params.get('q')
-    if (queryText) {
-      searchField.value = queryText
-      makeSearchEffect(queryText)
-    }
-
-    searchField.addEventListener('input', debounce(function (event) {
-      makeSearchEffect(event.target.value)
-    }, 150))
-
-    searchForm.addEventListener('reset', () => {
-      searchHits.innerHTML = ''
-      facetFilterList = []
-    })
-
     searchField.focus()
 
     searchForm.addEventListener('submit', event => {
@@ -109,6 +282,7 @@ function init() {
     })
 
     document.addEventListener('keydown', (event) => {
+      // Блокировка показа встроенного поиска в Firefox
       if (event.code === 'Slash' && document.activeElement !== searchField) {
         event.preventDefault()
       }
@@ -127,105 +301,15 @@ function init() {
     })
   }
 
-  function facetListenerBuilder(type) {
-    return function(event) {
-      const newFacetValue = event.target.value
+  assignSearchField()
 
-      switch (type) {
-        case 'category':
-          facetCategoryList = newFacetValue !== '' ? [newFacetValue] : []
-          break
-        case 'tag':
-          facetTagList = newFacetValue !== '' ? [newFacetValue]: []
-          break
-        default:
-          return
-      }
-
-      updateFacet()
-      makeSearchEffect(searchField.value.trim())
-    }
-  }
-
-  function assignFacetFields(categorySelector, tagSelector, outputSelector) {
-    const searchCategory = document.querySelector(categorySelector)
-    const searchTag = document.querySelector(tagSelector)
-    const searchHits = document.querySelector(outputSelector)
-
-    if (searchCategory && searchTag) {
-      searchCategory.addEventListener('change', facetListenerBuilder('category', searchHits))
-      searchTag.addEventListener('change', facetListenerBuilder('tag', searchHits))
-    }
-  }
-
-  document.addEventListener('DOMContentLoaded', function () {
-    assignSearchField(SEARCH_FIELD_SELECTOR, SEARCH_HITS_SELECTOR)
-    assignFacetFields(SEARCH_CATEGORY_SELECTOR, SEARCH_TAG_SELECTOR, SEARCH_HITS_SELECTOR)
+  filter.on('change', transformFiltersToSearchParamsOnChange)
+  filter.on('reset', transformFiltersToSearchParamsOnChange)
+  filter.on('reset', () => {
+    searchResultOutput.clear()
   })
-
-  function isPlaceholder(hitObject) {
-    return hitObject.tags.includes('placeholder')
-  }
-
-  function replaceBackticksByCode(text, replaceTemplate) {
-    return text.replace(/`(.*?)`/g, replaceTemplate)
-  }
-
-  const templates = {
-    mark: (match) => `<mark class="search-hit__marked">${match}</mark>`,
-
-    hit: (hitObject, query, limit) => {
-      const editIcon = isPlaceholder(hitObject)
-        ? '<span class="search-hit__edit font-theme font-theme--code" aria-hidden="true"></span>'
-        : ''
-      const title =
-        replaceBackticksByCode(
-          markQuery(
-            escape(hitObject.title),
-            query
-          ),
-          '<code class="search-hit__link-code font-theme font-theme--code">$1</code>'
-        )
-      const summary =
-        replaceBackticksByCode(
-          markQuery(
-            escape(adjustTextSize(hitObject.summary, query, limit)),
-            query
-          ),
-          '<code class="search-hit__text-code font-theme font-theme--code">$1</code>'
-        )
-
-      return `
-        <article class="search-hit" style="--accent-color: var(--color-base-${hitObject.category})">
-          <h3 class="search-hit__title">
-            <a class="search-hit__link link" href="${hitObject.url}">
-              ${editIcon}${title}
-            </a>
-          </h3>
-          <div class="search-hit__summary">
-            ${summary}
-          </div>
-        </article>
-      `
-    },
-
-    hits: (list, query, limit) => `
-      <ol class="search-result-list base-list">
-        ${
-          list.map(hitObject => `
-            <li class="search-result-list__item">
-              ${templates.hit(hitObject, query, limit)}
-            </li>
-          `)
-          .join('')
-        }
-      </ol>
-    `,
-
-    emptyResults: () => `
-      <div class="search-page__empty">Ничего не найдено</div>
-    `,
-  }
+  filter.on('change.filter', onFilterChange)
+  filter.on('change.query', debouncedOnFilterChange)
 }
 
 const isSearchPage = window.location.pathname.indexOf('/search/') > -1

--- a/src/styles/blocks/tag-filter.css
+++ b/src/styles/blocks/tag-filter.css
@@ -6,7 +6,9 @@
 }
 
 .tag-filter__control {
-  opacity: 0;
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
   position: absolute;
   left: 0;
   top: 0;
@@ -14,6 +16,7 @@
   width: 100%;
   height: 100%;
   cursor: pointer;
+  border-radius: 2em;
 }
 
 .tag-filter__text {

--- a/src/views/search.njk
+++ b/src/views/search.njk
@@ -1,7 +1,7 @@
 ---
 layout: 'base.njk'
 permalink: '/search/'
-title: 'Дока — Поиск'
+title: 'Поиск'
 ---
 {% from "blocks/header.njk" import header, divider %}
 {% from "blocks/footer.njk" import footer with context %}


### PR DESCRIPTION
Изменения:

- нормализует тег title, чтобы не было "Дока - Поиск - Дока"
- меняет CSS для контролов, чтобы рисовались стандартные браузерные стили для фокуса
- меняет имена и значения контролов на более понятные и отвязанные от Algolia, например, вместо `q` теперь `query`, вместо `<input name="filter-category" value="category:html"/>` теперь `<input name="category" value="html"/>`
- меняет radio на checkbox у фильтров категорий (Fix: #421, Fix: #826)
- удаляет атрибут `autocomplete="off"` у радио-инпутов, так как начальные значения теперь выставляются из строки url. Изменённые значения фильтров также сохраняются обратно в url (fix: #784)
- рефакорит код для использования компонентов для фильтров и для рендера результатов