### PR TITLE
Концепт. Переносит вычисление дат создания и обновления статей на сторону платформы

### DIFF
--- a/src/data/articlesDates.js
+++ b/src/data/articlesDates.js
@@ -27,6 +27,7 @@ function getCommitDates(filePath, options) {
   return executeProgram('git', `--no-pager log --format="%ci" -- ${filePath}`, options)
     .then(output => {
       const dates = output.split('\n')
+      dates.pop() // удаляем последний пустой элемент
       return {
         createdAt: dates.pop(),
         updatedAt: dates.shift()

--- a/src/data/articlesDates.js
+++ b/src/data/articlesDates.js
@@ -1,0 +1,74 @@
+const path = require('path')
+const util = require('util')
+const { execFile } = require('child_process')
+const { compose } = require('stream')
+
+const gulp = require('gulp')
+
+const { defaultPathToContent, mainSections } = require('../../config/constants')
+
+async function executeProgram(program, args, options) {
+  const { stdout } = await util.promisify(execFile)(program, args.split(' '), options)
+  return stdout
+}
+
+function getLastCommitDate(filePath, options) {
+  return executeProgram('git', `--no-pager log -n 1 --format="%ci" -- ${filePath}`, options)
+}
+
+function getFirstCommitDate(filePath, options) {
+  return executeProgram('git', `--no-pager log --reverse --format="%ci" -- ${filePath}`, options)
+    // `git log` с опцией `reverse -n1` выводит последний коммит, а не первый
+    // поэтому выводим списком и парсим
+    .then(output => output.split('\n')[0])
+}
+
+async function getDatesData() {
+  const pathToContent = path.resolve(process.cwd(), defaultPathToContent)
+  const articlesData = {}
+
+  const stream = compose(
+    gulp.src(`{${mainSections.join(',')}}/*/index.md`, {
+      cwd: pathToContent
+    }),
+    async function* (stream) {
+      for await (const file of stream) {
+        const articleId = path.relative(pathToContent, file.dirname)
+        const [createdAt, updatedAt] = await Promise.all([
+          getFirstCommitDate(articleId, { cwd: pathToContent }),
+          getLastCommitDate(articleId, { cwd: pathToContent })
+        ])
+        yield {
+          articleId,
+          createdAt,
+          updatedAt
+        }
+      }
+    }
+  )
+
+  for await (const chunk of stream) {
+    const { articleId, createdAt, updatedAt } = chunk
+
+    articlesData[articleId] = {
+      createdAt,
+      updatedAt
+    }
+  }
+
+  return articlesData
+}
+
+// вычисление дат через запуск процесса git занимает продолжительное время, поэтому делаем кеширование
+async function memo(func, key) {
+  if (!global[key]) {
+    global[key] = await func()
+  }
+
+  return global[key]
+}
+
+
+const getCachedDatesData = memo(getDatesData, '__articles-dates-data__')
+
+module.exports = getCachedDatesData

--- a/src/data/articlesDates.js
+++ b/src/data/articlesDates.js
@@ -52,7 +52,8 @@ async function getDatesData() {
   return articlesData
 }
 
-// вычисление дат через запуск процесса git занимает продолжительное время, поэтому делаем кеширование
+// Вычисление дат через запуск процесса git занимает продолжительное время, поэтому делаем кеширование.
+// Используется `global`, так как Eleventy чистит кеш модулей при пересборке
 async function memo(func, key) {
   if (!global[key]) {
     global[key] = await func()

--- a/src/data/articlesDates.js
+++ b/src/data/articlesDates.js
@@ -13,17 +13,6 @@ async function executeProgram(program, args, options) {
   return stdout
 }
 
-// function getLastCommitDate(filePath, options) {
-//   return executeProgram('git', `--no-pager log -n 1 --format="%ci" -- ${filePath}`, options)
-// }
-
-// function getFirstCommitDate(filePath, options) {
-//   return executeProgram('git', `--no-pager log --reverse --format="%ci" -- ${filePath}`, options)
-//     // `git log` с опцией `reverse -n1` выводит последний коммит, а не первый
-//     // поэтому выводим списком и парсим
-//     .then(output => output.split('\n')[0])
-// }
-
 function getCommitDates(filePath, options) {
   return executeProgram('git', `--no-pager log --format="%ci" -- ${filePath}`, options)
     .then(output => {

--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -1,6 +1,4 @@
-const util = require('util')
-const { execFile } = require('child_process')
-const { baseUrl, defaultPathToContent } = require('../../config/constants')
+const { baseUrl } = require('../../config/constants')
 const { titleFormatter } = require('../libs/title-formatter/title-formatter')
 
 function getPersons(personGetter) {
@@ -31,22 +29,6 @@ function getPopulatedPersons(personKey) {
 
 function hasTag(tags, tag) {
   return (tags || []).includes(tag)
-}
-
-async function executeProgram(program, args, options) {
-  const { stdout } = await util.promisify(execFile)(program, args.split(' '), options)
-  return stdout
-}
-
-function getLastCommitDate(filePath, options) {
-  return executeProgram('git', `--no-pager log -n 1 --format="%ci" -- ${filePath}`, options)
-}
-
-function getFirstCommitDate(filePath, options) {
-  return executeProgram('git', `--no-pager log --reverse --format="%ci" -- ${filePath}`, options)
-    // `git log` с опцией `reverse -n1` выводит последний коммит, а не первый
-    // поэтому выводим списком и парсим
-    .then(output => output.split('\n')[0])
 }
 
 module.exports = {
@@ -155,30 +137,26 @@ module.exports = {
       return practices.length > 0 ? 'true' : 'false'
     },
 
-    createdAt: async function(data) {
-      const { docId } = data
+    createdAt: function(data) {
+      const { docId, articlesDates } = data
 
       if (!docId) {
         return
       }
 
-      const date = await getFirstCommitDate(docId, {
-        cwd: defaultPathToContent
-      })
+      const date = articlesDates[docId].createdAt
 
       return date ? new Date(date) : null
     },
 
-    updatedAt: async function(data) {
-      const { docId } = data
+    updatedAt: function(data) {
+      const { docId, articlesDates } = data
 
       if (!docId) {
         return
       }
 
-      const date = await getLastCommitDate(docId, {
-        cwd: defaultPathToContent
-      })
+      const date = articlesDates[docId].updatedAt
 
       return date ? new Date(date) : null
     },


### PR DESCRIPTION
Хочется сохранять репозиторий контента макисмально чистым и отвязанными от инструментов сборки, поэтому цель данного PR - удалить файлы `index.11tydata.json` и соответсвующие github actions из репозитория контента.

Проблемы, которые нужно решить:

- Производительность сборки на стороне платформы. Для вычисления двух полей `updatedAt` и `createdAt` запускаются дочерние процессы git, что весьма затратно. Eleventy должен кэшировать вычисляемые поля, но этого не происходит. Можно решить путём выноса в глобальные дата-файлы и ручного кеширования там или исползовать Github API.

- Производительность сборки на стороне github actions. Для вычисления даты создания используется дата первого коммита. Скорее всего, потребуется выкачивать весь репозиторий. Многие actions решают эту проблему используя Github API, а не сам git внутри action. Также для ускорения выкачивания в CI/CD можно использовать клонирование репозитория с опцией `--bare` (хотя Github Actions, возможно, и так использует такие настройки). Но для этого список статей нужно получать как-то отдельно.

- Путь до репозитория контента. Папки контента и платформы могут лежать в разных местах, поэтому нужно всегда точно передевать путь до контента, например, как env-переменную, во всех скриптах и конфигах. Частично решается в [PR 882](https://github.com/doka-guide/platform/pull/882).