### PR TITLE
Фикс цвета комментариев в темной теме

### DIFF
--- a/src/styles/code-dark-theme.css
+++ b/src/styles/code-dark-theme.css
@@ -91,7 +91,7 @@ pre[class*="language-"] {
 .token.comment,
 .token.prolog,
 .token.cdata {
-  color: hsl(220, 10%, 40%);
+  color: hsl(220, 10%, 48%);
 }
 
 .token.doctype,

--- a/src/styles/code-light-theme.css
+++ b/src/styles/code-light-theme.css
@@ -80,7 +80,7 @@ pre[class*="language-"] {
 .token.comment,
 .token.prolog,
 .token.cdata {
-  color: hsl(230, 4%, 64%);
+  color: hsl(230, 2%, 47%);
 }
 
 .token.doctype,


### PR DESCRIPTION
Ближайший похожий цвет в палитре с достаточной контрастностью это `--mono-2`

Fixes #813