### PR TITLE
Добавляет `overflow: auto` для блоков callout

### DIFF
--- a/src/styles/blocks/callout.css
+++ b/src/styles/blocks/callout.css
@@ -4,6 +4,7 @@
   display: flex;
   align-items: baseline;
   gap: 10px;
+  overflow: auto;
   box-sizing: border-box;
   padding: 10px;
   overflow-wrap: break-word;


### PR DESCRIPTION
- Было: https://doka.guide/js/reactivity/
- Стало: https://doka-guide-platform-pr-851.surge.sh/js/reactivity/

Fix: #842