### PR TITLE
Добавляет фикс для breakify угловых скобок

### DIFF
--- a/src/transforms/code-breakify-transform.js
+++ b/src/transforms/code-breakify-transform.js
@@ -1,5 +1,5 @@
 function breakify(content) {
-  const symbols = ['.', ',', '-', '_', '=', ';', ':', '~', '/', '\\', '?', '#', '%', '(', ')', '[', ']']
+  const symbols = ['.', ',', '-', '_', '=', ':', '~', '/', '\\', '?', '#', '%', '(', ')', '[', ']']
 
   for (const symbol of symbols) {
     content = content.replaceAll(symbol, (match) => `<wbr>${match}<wbr>`)


### PR DESCRIPTION
Удалил пока символ `;`, так как ломается вывод `&lt;` и `&gt;`. 
Нужно будет пересмотреть обработку символов.

Можно также решить заменой `&lt;` на `<`, затем добавить `<wbr>` для `<` и заменить обратно на `&lt;`