### PR TITLE
Правит селекторы в js-модуле расстановки номеров строк

### DIFF
--- a/src/scripts/modules/code-line-numbers.js
+++ b/src/scripts/modules/code-line-numbers.js
@@ -9,8 +9,8 @@ function init() {
 
   function computedHeights() {
     codeBlocks.forEach((block) => {
-      const originalLines = block.querySelectorAll('.code-block__original-line')
-      const linesMarkers = block.querySelectorAll('.code-block__line')
+      const originalLines = block.querySelectorAll('.block-code__original-line')
+      const linesMarkers = block.querySelectorAll('.block-code__line')
 
       originalLines.forEach((line, index) => {
         linesMarkers[index].style.height = `${getComputedStyle(line).height}`


### PR DESCRIPTION
Забыли поправить после правок конфликтов именования с бибилотекой prism.js