### PR TITLE
Добавляет игнорирование преобразований для внешних изображений

### DIFF
--- a/src/transforms/image-transform.js
+++ b/src/transforms/image-transform.js
@@ -58,6 +58,8 @@ module.exports = function (window, content, outputPath) {
   const images = Array.from(articleContainer.querySelectorAll('img'))
     // игнорируем изображения, которые находятся внутри figure, picture
     .filter((image) => !image.matches('figure > img, picture > img'))
+    // игнорируем внешние изображения
+    .filter((image) => image.src.startsWith('https://') || image.src.startsWith('http://'))
 
   return Promise.all(images.map((image) => buildImage(image, imagesSourcePath, imagesOutputPath, window)))
 }


### PR DESCRIPTION
Например, в статье `tools/markdown` в последнем совете есть неэкранированное от преобразований изображение