### PR TITLE
Убирает принудительную якорную js-прокрутку до заголовка

### DIFF
--- a/src/scripts/modules/toc.js
+++ b/src/scripts/modules/toc.js
@@ -81,13 +81,16 @@ function init() {
     )
   }
 
+  function saveHistory(hash) {
+    history.pushState(null, null, hash)
+  }
+
   function scrollToTitle(hash) {
     const title = getTitleFromHash(hash)
     window.scrollTo({
       top: getTitleScrollPosition(title),
       behavior: 'smooth',
     })
-    history.pushState(null, null, hash)
   }
 
   links.forEach((link) => {
@@ -144,10 +147,6 @@ function init() {
     if (nearestTitle) {
       setActiveTitle(nearestTitle)
     }
-
-    if (window.location.hash) {
-      scrollToTitle(window.location.hash)
-    }
   })
 
   document.querySelector(TOC_CONTAINER_SELECTOR)?.addEventListener('click', (event) => {
@@ -159,6 +158,7 @@ function init() {
 
     event.preventDefault()
     scrollToTitle(link.hash)
+    saveHistory(link.hash)
   })
 }
 


### PR DESCRIPTION
Fix: #859

У Chrome вроде больше нет проблем с начальным скроллом до заголовка, по крайней мере на странице статьи. Поэтому js-скролл на событии load можно убрать.