### PR TITLE
Устраняет невозможность отправки формы в быстром поиске после навигации стрелками и закрытия списка

### DIFF
--- a/src/scripts/modules/quick-search.js
+++ b/src/scripts/modules/quick-search.js
@@ -41,7 +41,7 @@ class QuickSearch extends BaseComponent {
         event.preventDefault()
       }
 
-      if (this.state.highlightedIndex >= 0) {
+      if (this.state.highlightedIndex >= 0 && this.isSuggestionOpen) {
         event.preventDefault()
       }
     })


### PR DESCRIPTION
Устраняет следующий баг:
- в быстром поиске что-нибудь ввести, чтобы появились результаты
- выбрать стрелками какой-нибудь пункт
- закрыть список с помощью `Esc`
- попробовать отправить форму по нажатию `Enter`
Результат: форма не отправляется.

Здесь предложен вариант проверки на открытие списка `this.isSuggestionOpen`, но, возможно, лучше чистить состояние `this.state.highlightedIndex` при закрытии.
