### PR TITLE
Удаляет обработку бектиков в теле поискового сниппета

### DIFF
--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -105,13 +105,10 @@ class SearchResultOutput extends BaseComponent {
       hit: (hitObject) => {
         const editIcon = SearchResultOutput.isPlaceholder(hitObject) ? SearchResultOutput.templates.placeholderIcon : ''
         const title = SearchResultOutput.replaceBackticks(hitObject.title, SearchResultOutput.templates.titleCode)
-        const summary = SearchResultOutput.replaceBackticks(
-          hitObject.summary
-            .slice(0, SearchResultOutput.matchedItems)
-            .map((item) => SearchResultOutput.templates.summaryItem(item))
-            .join(''),
-          SearchResultOutput.templates.textCode
-        )
+        const summary = hitObject.summary
+          .slice(0, SearchResultOutput.matchedItems)
+          .map((item) => SearchResultOutput.templates.summaryItem(item))
+          .join('')
 
         return `
           <article class="search-hit" style="--accent-color: var(--color-base-${hitObject.category})">


### PR DESCRIPTION
В результаты поиска сейчас попадает код из элементов `pre`, там могут встречаться символы обратных кавычек, например, в JavaScript.

Как быстрое решение - удалить обработку бектиков. Другие варианты - в поисковом индексе добавлять тип блока - текст или код - и исходя из него выбирать, обрабатывать или нет кавычки.