### PR TITLE
Делает шаринг Доки работающим, правит размер шаринг-картинок Twitter-варианта

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,7 +155,7 @@ const socialCards = async () => {
             x: 0,
             y: 0,
             width: 1024,
-            height: 1024,
+            height: 630,
           },
         })
 

--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -87,7 +87,6 @@
 {% endif %}
 
 <meta property="twitter:image" content="{{ defaultTwitterPath }}">
-<meta property="twitter:card" content="summary">
 <meta property="twitter:site" content="@doka_guide">
 
 <!-- 10.3 Microdata -->

--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -76,6 +76,10 @@
 <meta property="og:locale" content="ru_RU">
 <meta property="og:site_name" content="Дока">
 
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="600">
+<meta property="og:image:height" content="315">
+
 <!-- 10.2 Twitter -->
 
 <meta property="twitter:card" content="summary_large_image">


### PR DESCRIPTION
## Что происходит

Самый важный пункт — удалён дубль в `src/includes/meta.njk`.

```diff
- <meta property="twitter:card" content="summary">
```

Ну и правит картинки для twitter-варианта. Они ж квадратно-гигантские: https://doka.guide/js/deal-with-forms/images/covers/twitter.png

В среднем за часа 72 соцсети сами обновляют кэш для шаринга. Если нечто, что нужно обновить — популярно, 
Но частные случаи нужно будет разруливать руками.

## Где и как чистить кэш

* FB: https://developers.facebook.com/tools/debug/
* Twitter: https://cards-dev.twitter.com/validator
* VK: https://vk.com/dev/pages.clearCache
* Tlgrm: https://t.me/WebpageBot 

## Организационное
Открытых ишью про это не нашёл, с чем линковать — не представлю.
И не поставил приставку `fix-` для имени ветки. Сорян.