### PR TITLE
Изменяет размеры заголовков четвёртого и пятого уровня

### DIFF
--- a/src/styles/blocks/article-heading.css
+++ b/src/styles/blocks/article-heading.css
@@ -37,26 +37,32 @@
 
 .article-heading--level-1,
 .article-heading--level-1 > * {
-  --font-size: var(--font-size-xxl);
-  --line-height: var(--font-line-height-xxl);
+  --font-size: var(--font-size-headline-1);
+  --line-height: var(--font-line-height-headline-1);
 }
 
 .article-heading--level-2,
 .article-heading--level-2 > * {
-  --font-size: var(--font-size-xl);
-  --line-height: var(--font-line-height-xl);
+  --font-size: var(--font-size-headline-2);
+  --line-height: var(--font-line-height-headline-2);
 }
 
 .article-heading--level-3,
 .article-heading--level-3 > * {
-  --font-size: var(--font-size-l);
-  --line-height: var(--font-line-height-l);
+  --font-size: var(--font-size-headline-3);
+  --line-height: var(--font-line-height-headline-3);
 }
 
 .article-heading--level-4,
 .article-heading--level-4 > * {
-  --font-size: var(--font-size-m);
-  --line-height: var(--font-line-height-m);
+  --font-size: var(--font-size-headline-4);
+  --line-height: var(--font-line-height-headline-4);
+}
+
+.article-heading--level-5,
+.article-heading--level-5 > * {
+  --font-size: var(--font-size-headline-5);
+  --line-height: var(--font-line-height-headline-5);
 }
 
 .article-heading--level-2 {
@@ -65,7 +71,8 @@
 }
 
 .article-heading--level-3,
-.article-heading--level-4 {
+.article-heading--level-4,
+.article-heading--level-5 {
   margin-top: 20px;
   margin-bottom: 10px;
 }
@@ -81,7 +88,8 @@
   }
 
   .article-heading--level-3,
-  .article-heading--level-4 {
+  .article-heading--level-4,
+  .article-heading--level-5 {
     margin-top: 24px;
     margin-bottom: 16px;
   }
@@ -94,7 +102,8 @@
   }
 
   .article-heading--level-3,
-  .article-heading--level-4 {
+  .article-heading--level-4,
+  .article-heading--level-5 {
     margin-top: 40px;
     margin-bottom: 20px;
   }

--- a/src/styles/blocks/font-theme.css
+++ b/src/styles/blocks/font-theme.css
@@ -18,6 +18,21 @@
 
   --font-size-xxl: 50px;
   --font-line-height-xxl: 54px;
+
+  --font-size-headline-1: var(--font-size-xxl);
+  --font-line-height-headline-1: var(--font-line-height-xxl);
+
+  --font-size-headline-2: var(--font-size-xl);
+  --font-line-height-headline-2: var(--font-line-height-xl);
+
+  --font-size-headline-3: var(--font-size-l);
+  --font-line-height-headline-3: var(--font-line-height-l);
+
+  --font-size-headline-4: 22px;
+  --font-line-height-headline-4: 26px;
+
+  --font-size-headline-5: 19px;
+  --font-line-height-headline-5: 19px;
 }
 
 .font-theme--code {
@@ -58,6 +73,12 @@
 
     --font-size-xxl: 50px;
     --font-line-height-xxl: 54px;
+
+    --font-size-headline-4: 24px;
+    --font-line-height-headline-4: 24px;
+
+    --font-size-headline-5: 20px;
+    --font-line-height-headline-5: 20px;
   }
 
   .font-theme--code {
@@ -95,6 +116,12 @@
 
     --font-size-xxl: 50px;
     --font-line-height-xxl: 54px;
+
+    --font-size-headline-4: 26px;
+    --font-line-height-headline-4: 32px;
+
+    --font-size-headline-5: 22px;
+    --font-line-height-headline-5: 26px;
   }
 
   .font-theme--code {
@@ -132,6 +159,12 @@
 
     --font-size-xxl: 60px;
     --font-line-height-xxl: 60px;
+
+    --font-size-headline-4: 32px;
+    --font-line-height-headline-4: 38px;
+
+    --font-size-headline-5: 26px;
+    --font-line-height-headline-5: 32px;
   }
 
   .font-theme--code {


### PR DESCRIPTION
## Что случилось

Правим размеры заголовков четвёртого и пятого уровня в статьях. 
Closes #6

## Решение

Предыдущая версия заголовков использует шкалу размеров шрифта (xxl, xl, l, m, s, xs). Новые размеры заголовков в этой шкале отсутствуют. 

Я решил не добавлять их в шкалу так как у нас всего один случай использования таких размеров, а создать отдельные переменные для заголовков, которые будут обращаться либо к шкале (заголовки 1,2,3), либо иметь захардкоженые значения (заголовки 4,5).

🎤 Рассказываю про решение на видео:

<a href="https://www.loom.com/share/27e26fc89e6644dfa79b9c9d5d04053e">
    <p>Заголовки четвертого и пятого уровней - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/27e26fc89e6644dfa79b9c9d5d04053e-with-play.gif">
  </a>

## Результат

<img width="1615" alt="image" src="https://user-images.githubusercontent.com/1469636/171049495-5571f1bc-9659-4ea9-b9e2-cb22b684ea85.png">