### PR TITLE
Убирает скролл на странице поиска (doka-guide/platform#939)

### DIFF
--- a/src/styles/blocks/search-page.css
+++ b/src/styles/blocks/search-page.css
@@ -237,11 +237,18 @@
   }
 
   .search-page__main {
+    grid-column: 2/-1;
     justify-self: center;
   }
 
   .search-page__footer {
     grid-column-start: 2;
     grid-column-end: -1;
+  }
+}
+
+@media (min-width: 1240px) {
+  .search-page__main {
+    grid-column: auto;
   }
 }

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -63,12 +63,6 @@
   display: none;
 }
 
-@media (min-width: 1024px) {
-  .search__output:not(:empty) > .search-result-list {
-    width: 809px;
-  }
-}
-
 .search__suggestion {
   --lightness: calc(100% - var(--is-dark-theme-on) * 80%);
   --background-opacity: 0.96;


### PR DESCRIPTION
Убрал жёсткое указание ширины, которые вызывало скролл. На экранах от 1024 до 1240 найденный контент будет занимать всю оставшуюся ширину, а после 1240px найденный контент будет увеличиваться с 560 до 809 пикселей.