### PR TITLE
Фиксит ссылку в шапке на странице участников

### DIFF
--- a/src/views/people.njk
+++ b/src/views/people.njk
@@ -21,6 +21,7 @@
 <div class="people-page">
   {{ header(
     category=title,
+    pageCategoryId='people',
     title=title
   ) }}
 


### PR DESCRIPTION
Если зайти на страницу участников и кликнуть по заголовке в шапке, мы получим ошибку.

Safari:

<img width="1495" alt="Screenshot 2022-07-06 at 15 55 28" src="https://user-images.githubusercontent.com/50330458/177555016-6ab31445-51a9-4829-a699-a9d6c3a37113.png">

Chrome и Яндекс Браузер выдают пустую страницу с URL: `about:blank#blocked`

Firefox на ошибку не реагирует.

Так происходит потому, что на странице людей сломана логика остальных страниц. У страницы нет заголовка (кстати, а нормально, что `<h1>` отсутствует?), а то что имеет название страницы спрятано в «хлебных крошках» и не имеет параметра `pageCategoryId`, который есть на странице каждого конкретного человека. 

Этот PR добавляет такой id, из-за чего ссылка на заголовке на слове «Участники» начинает работать. 

В следующей итерации можно было бы:

1. Вынести заголовок на страницу
1. Убрать ссылку на этом заголовке, она там не нужна.
