### PR TITLE
Убирает ссылку на странице со всеми участниками

### DIFF
--- a/src/views/people.njk
+++ b/src/views/people.njk
@@ -1,6 +1,7 @@
 {% from "blocks/header.njk" import header with context %}
 {% from "blocks/footer.njk" import footer with context %}
 {% from "blocks/person.njk" import person %}
+{% set exeptionURL = "/people/" %}
 
 {% macro peopleGridItem(data) %}
   {%- set dataCategories -%}
@@ -19,11 +20,18 @@
 {% endmacro %}
 
 <div class="people-page">
+  {% if page.url == exeptionURL %}
+  {{ header(
+    category=title,
+    pageCategoryId='people'
+  ) }}
+  {% else %}
   {{ header(
     category=title,
     pageCategoryId='people',
     title=title
   ) }}
+  {% endif %}
 
   <main class="people-page__main">
     <form class="people-page__filter filter-panel" autocomplete="off">


### PR DESCRIPTION
Продолжение #954

В текущей версии на странице всех контрибьюторов есть [ссылка на слове «Люди»](https://doka.guide/people/) и косая черта после него. 

<details>
<summary>Пример</summary>

![Screenshot 2022-07-08 at 09 23 09](https://user-images.githubusercontent.com/50330458/177930009-6114b041-a5f4-4026-9ded-b6974b09ef31.png)

</details>

Это выбивается из общей логики построения заголовка на страницах-оглавлениях, где название заголовка ссылкой не является и косой черты не содержит. 

<details>
<summary>Пример</summary>

![Screenshot 2022-07-08 at 09 26 11](https://user-images.githubusercontent.com/50330458/177930257-179f0e18-8c25-4121-957a-5aa95176e3df.png)

</details>

Так же ссылка, которая ведёт на ту же страницу, где находится пользователь, может его озадачить. У нас ссылки всегда ведут на какой-то полезный контент.

Этот PR 

1. Удаляет ссылку у заголовка на странице-сборщике всех участников, но сохраняет её на странице конкретного контрибьютора, чтобы можно было перейти на уровень выше, как это сделано в наших статьях

    <details>
    <summary>Пример страницы участника</summary>
    
    ![Screenshot 2022-07-08 at 09 28 54](https://user-images.githubusercontent.com/50330458/177930837-670c93c5-d42f-4db3-a554-6ac5a65aa285.png)
    
    </details>

    <details>
    <summary>Страница всех участников</summary>
    
    ![Screenshot 2022-07-08 at 09 33 18](https://user-images.githubusercontent.com/50330458/177931265-736ffe3b-3f95-4abc-9992-4c0fe64c6c90.png)
    
    </details>

    
    <details>
    <summary>Пример статьи</summary>
    
    ![Screenshot 2022-07-08 at 09 29 33](https://user-images.githubusercontent.com/50330458/177930854-85f764ee-58bf-405a-87e5-7e42fe5b8583.png)
    
    </details>

2. Аналогичным образом поступает с косой чертой после заголовка. 