### PR TITLE
Изменяет дизайн хедера

### DIFF
--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -4,12 +4,12 @@
   <span class="header__divider {% if isLarge %}header__divider--large{% endif %} font-theme font-theme--code" aria-hidden="true"></span>
 {% endmacro %}
 
-{% macro header(pageCategoryId, category, title, link, isLogoContrastColor, hasAccentColor, isLogoImageHidden = false) %}
+{% macro header(pageCategoryId, category, title, link, isLogoContrastColor, hasAccentColor, isMainPage = false, isLogoImageHidden = false) %}
   {% set articleIndexes = collections.articleIndexes %}
   <header
     class="
       header
-      {% if isMainPage %}header--open{% endif %}
+      {% if isMainPage %}header--main{% endif %}
       {% if not hasAccentColor %}header--simple{% endif %}
     "
   >
@@ -17,7 +17,7 @@
       <ul class="header__breadcrumbs breadcrumbs base-list">
         <li class="breadcrumbs__item header__logo">
           {{ logo(isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
-          {% if title %}{{ divider() }}{% endif %}
+          {% if not isMainPage %}{{ divider() }}{% endif %}
         </li>
 
         {% if category %}
@@ -30,7 +30,6 @@
             </li>
           {% else %}
             <li class="breadcrumbs__item header__category header__category--standalone">
-              {{ divider() }}
               <span class="breadcrumbs__text">
                 {{ category }}
               </span>

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -18,7 +18,7 @@
       <div class="header__inner header__inner--main font-theme font-theme--code">
         <ul class="header__breadcrumbs breadcrumbs base-list">
           <li class="breadcrumbs__item">
-            {{ logo(class="header__logo", isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
+            {{ logo(isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
             {{ divider() }}
           </li>
 

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -9,7 +9,7 @@
   <header
     class="
       header
-      {% if isMainPage %}header--main{% endif %}
+      {% if isMainPage %}header--main header--open{% endif %}
       {% if not hasAccentColor %}header--simple{% endif %}
     "
   >

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -4,65 +4,62 @@
   <span class="header__divider {% if isLarge %}header__divider--large{% endif %} font-theme font-theme--code" aria-hidden="true"></span>
 {% endmacro %}
 
-{% macro header(pageCategoryId, category, title, link, isStatic, isLogoContrastColor, hasAccentColor, isLogoImageHidden = false) %}
+{% macro header(pageCategoryId, category, title, link, isLogoContrastColor, hasAccentColor, isLogoImageHidden = false) %}
   {% set articleIndexes = collections.articleIndexes %}
   <header
     class="
       header
       {% if isMainPage %}header--open{% endif %}
-      {% if isStatic %}header--static{% endif %}
       {% if not hasAccentColor %}header--simple{% endif %}
     "
   >
-    {% if not isStatic %}
-      <div class="header__inner header__inner--main font-theme font-theme--code">
-        <ul class="header__breadcrumbs breadcrumbs base-list">
-          <li class="breadcrumbs__item">
-            {{ logo(isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
-            {{ divider() }}
-          </li>
+    <div class="header__inner header__inner--main font-theme font-theme--code">
+      <ul class="header__breadcrumbs breadcrumbs base-list">
+        <li class="breadcrumbs__item">
+          {{ logo(isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
+          {{ divider() }}
+        </li>
 
-          {% if category %}
-            {% if title %}
-              <li class="breadcrumbs__item header__category">
-                <a class="breadcrumbs__text link" href="/{{ pageCategoryId }}/">
-                  {{ category }}
-                </a>
-                {{ divider() }}
-              </li>
-            {% else %}
-              <li class="breadcrumbs__item header__category header__category--standalone">
-                <span class="breadcrumbs__text">
-                  {{ category }}
-                </span>
-              </li>
-            {% endif %}
-          {% endif %}
-
+        {% if category %}
           {% if title %}
-            <li class="breadcrumbs__item breadcrumbs__item--shrink header__title">
-              <span class="breadcrumbs__text" title="{{ title | replace('`', '') }}">
-                {{ title | descriptionMarkdown | safe }}
+            <li class="breadcrumbs__item header__category">
+              <a class="breadcrumbs__text link" href="/{{ pageCategoryId }}/">
+                {{ category }}
+              </a>
+              {{ divider() }}
+            </li>
+          {% else %}
+            <li class="breadcrumbs__item header__category header__category--standalone">
+              <span class="breadcrumbs__text">
+                {{ category }}
               </span>
             </li>
           {% endif %}
-        </ul>
+        {% endif %}
 
-        <div class="header__toggle">
-          <button class="menu-toggle" type="button">
-            <span class="visually-hidden">Открыть меню</span>
-            <span class="menu-toggle__inner menu-toggle__inner--open">
-              <kbd class="hotkey font-theme font-theme--code">/</kbd>
-              <span class="menu-toggle__icon menu-toggle__icon--open">
-                <span class="menu-toggle__dot"></span>
-                <span class="menu-toggle__dot"></span>
-                <span class="menu-toggle__dot"></span>
-              </span>
+        {% if title %}
+          <li class="breadcrumbs__item breadcrumbs__item--shrink header__title">
+            <span class="breadcrumbs__text" title="{{ title | replace('`', '') }}">
+              {{ title | descriptionMarkdown | safe }}
             </span>
-          </button>
-        </div>
+          </li>
+        {% endif %}
+      </ul>
+
+      <div class="header__toggle">
+        <button class="menu-toggle" type="button">
+          <span class="visually-hidden">Открыть меню</span>
+          <span class="menu-toggle__inner menu-toggle__inner--open">
+            <kbd class="hotkey font-theme font-theme--code">/</kbd>
+            <span class="menu-toggle__icon menu-toggle__icon--open">
+              <span class="menu-toggle__dot"></span>
+              <span class="menu-toggle__dot"></span>
+              <span class="menu-toggle__dot"></span>
+            </span>
+          </span>
+        </button>
       </div>
-    {% endif %}
+    </div>
 
     <div class="header__inner header__inner--menu">
       <div class="header__logo">
@@ -73,20 +70,18 @@
       {% include "blocks/search.njk" %}
       {% include "blocks/nav-list.njk" %}
 
-      {% if not isStatic %}
-        <div class="header__toggle">
-          <button class="menu-toggle" type="button">
-            <span class="visually-hidden">Закрыть меню</span>
-            <span class="menu-toggle__inner menu-toggle__inner--close">
-              <kbd class="hotkey font-theme font-theme--code">esc</kbd>
-              <svg class="menu-toggle__icon menu-toggle__icon--close" width="45" height="45" viewBox="0 0 45 45">
-                <circle cx="22.5" cy="22.5" r="22.5" fill="var(--color-text)" />
-                <path fill="var(--color-background)" d="M30.3 32.1c-.5 0-1-.2-1.4-.6l-6.5-6.6-6.5 6.5c-.5.5-1 .7-1.5.7-.4 0-.8-.1-1-.4-.3-.3-.5-.6-.5-1 0-.6.3-1.1.7-1.6l6.5-6.5-6.5-6.4c-.4-.5-.7-1-.7-1.5s.2-.8.4-1.1c.3-.3.7-.4 1.1-.4.5 0 1 .2 1.5.7l6.5 6.5 6.5-6.6c.5-.5 1-.7 1.5-.7.3 0 .7.2 1 .5.3.4.5.8.5 1.1 0 .5-.2 1-.7 1.4l-6.5 6.5 6.5 6.6c.5.5.7 1 .7 1.4 0 .4-.1.7-.5 1-.4.4-.7.5-1 .5z"/>
-              </svg>
-            </span>
-          </button>
-        </div>
-      {% endif %}
+      <div class="header__toggle">
+        <button class="menu-toggle" type="button">
+          <span class="visually-hidden">Закрыть меню</span>
+          <span class="menu-toggle__inner menu-toggle__inner--close">
+            <kbd class="hotkey font-theme font-theme--code">esc</kbd>
+            <svg class="menu-toggle__icon menu-toggle__icon--close" width="45" height="45" viewBox="0 0 45 45">
+              <circle cx="22.5" cy="22.5" r="22.5" fill="var(--color-text)" />
+              <path fill="var(--color-background)" d="M30.3 32.1c-.5 0-1-.2-1.4-.6l-6.5-6.6-6.5 6.5c-.5.5-1 .7-1.5.7-.4 0-.8-.1-1-.4-.3-.3-.5-.6-.5-1 0-.6.3-1.1.7-1.6l6.5-6.5-6.5-6.4c-.4-.5-.7-1-.7-1.5s.2-.8.4-1.1c.3-.3.7-.4 1.1-.4.5 0 1 .2 1.5.7l6.5 6.5 6.5-6.6c.5-.5 1-.7 1.5-.7.3 0 .7.2 1 .5.3.4.5.8.5 1.1 0 .5-.2 1-.7 1.4l-6.5 6.5 6.5 6.6c.5.5.7 1 .7 1.4 0 .4-.1.7-.5 1-.4.4-.7.5-1 .5z"/>
+            </svg>
+          </span>
+        </button>
+      </div>
     </div>
   </header>
 {% endmacro %}

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -16,7 +16,7 @@
     <div class="header__inner header__inner--main font-theme font-theme--code">
       <ul class="header__breadcrumbs breadcrumbs base-list">
         <li class="breadcrumbs__item header__logo">
-          {{ logo(isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
+          {{ logo(isLink=not isMainPage, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
           {% if not isMainPage %}{{ divider() }}{% endif %}
         </li>
 
@@ -64,7 +64,7 @@
     <div class="header__inner header__inner--menu">
       <div class="header__logo">
         {{ logo(
-          isLink=true,
+          isLink=not isMainPage,
           letters='U<span class="logo__eye">&gt;</span><span class="logo__nose">ᴥ</span><span class="logo__eye">&lt;</span>U'
         ) }}
         {{ divider(isLarge=true) }}

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -30,6 +30,7 @@
             </li>
           {% else %}
             <li class="breadcrumbs__item header__category header__category--standalone">
+              {{ divider() }}
               <span class="breadcrumbs__text">
                 {{ category }}
               </span>

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -4,7 +4,7 @@
   <span class="header__divider {% if isLarge %}header__divider--large{% endif %} font-theme font-theme--code" aria-hidden="true"></span>
 {% endmacro %}
 
-{% macro header(pageCategoryId, category, title, link, isLogoContrastColor, hasAccentColor, isMainPage = false, isLogoImageHidden = false) %}
+{% macro header(pageCategoryId, category, title, link, isLogoContrastColor, hasAccentColor, isMainPage = false, isCategoryVisible = false, isLogoImageHidden = false) %}
   {% set articleIndexes = collections.articleIndexes %}
   <header
     class="
@@ -22,14 +22,14 @@
 
         {% if category %}
           {% if title %}
-            <li class="breadcrumbs__item header__category">
+            <li class="breadcrumbs__item header__category {% if isCategoryVisible %}header__category--visible{% endif %}">
               <a class="breadcrumbs__text link" href="/{{ pageCategoryId }}/">
                 {{ category }}
               </a>
               {{ divider() }}
             </li>
           {% else %}
-            <li class="breadcrumbs__item header__category header__category--standalone">
+            <li class="breadcrumbs__item header__category {% if isCategoryVisible %}header__category--visible{% else %}header__category--standalone{% endif %}">
               <span class="breadcrumbs__text">
                 {{ category }}
               </span>

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -15,7 +15,7 @@
   >
     <div class="header__inner header__inner--main font-theme font-theme--code">
       <ul class="header__breadcrumbs breadcrumbs base-list">
-        <li class="breadcrumbs__item">
+        <li class="breadcrumbs__item header__logo">
           {{ logo(isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
           {% if title %}{{ divider() }}{% endif %}
         </li>
@@ -63,7 +63,10 @@
 
     <div class="header__inner header__inner--menu">
       <div class="header__logo">
-        {{ logo(isLink=true) }}
+        {{ logo(
+          isLink=true,
+          letters='U<span class="logo__eye">&gt;</span><span class="logo__nose">ᴥ</span><span class="logo__eye">&lt;</span>U'
+        ) }}
         {{ divider(isLarge=true) }}
       </div>
 

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -17,7 +17,7 @@
       <ul class="header__breadcrumbs breadcrumbs base-list">
         <li class="breadcrumbs__item">
           {{ logo(isLink=true, isContrastColor=isLogoContrastColor, isImageHidden=isLogoImageHidden, letters=logoLetters) }}
-          {{ divider() }}
+          {% if title %}{{ divider() }}{% endif %}
         </li>
 
         {% if category %}

--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -64,8 +64,7 @@
     <div class="header__inner header__inner--menu">
       <div class="header__logo">
         {{ logo(
-          isLink=not isMainPage,
-          letters='U<span class="logo__eye">&gt;</span><span class="logo__nose">ᴥ</span><span class="logo__eye">&lt;</span>U'
+          isLink=not isMainPage
         ) }}
         {{ divider(isLarge=true) }}
       </div>

--- a/src/includes/blocks/logo.njk
+++ b/src/includes/blocks/logo.njk
@@ -17,7 +17,7 @@
 
   <{{tag}} class="{{ classes }}" {{ attrs }}>
     {% if (not isImageHidden) %}
-      <div class="logo__image" aria-hidden="true">
+      <div class="logo__image {{ 'logo__image--contrast' if not isContrastColor else '' }}" aria-hidden="true">
         <div class="logo__symbols logo__symbols--main">
           {{ letters | safe }}
         </div>
@@ -26,6 +26,6 @@
         </div>
       </div>
     {% endif %}
-    <div class="logo__text {{ 'link' if isLink else '' }}">Дока</div>
+    <div class="logo__text {{ 'link' if isLink else '' }} {{ 'logo__text--contrast' if not isContrastColor else '' }}">Дока</div>
   </{{tag}}>
 {% endmacro %}

--- a/src/includes/blocks/logo.njk
+++ b/src/includes/blocks/logo.njk
@@ -11,7 +11,7 @@
   {% endset %}
 
   {% set defaultLetters %}
-    U<span class="logo__eye">·</span>ᴥ<span class="logo__eye">·</span>U
+    U<span class="logo__eye">•</span><span class="logo__nose">ᴥ</span><span class="logo__eye">•</span>U
   {% endset %}
   {% set letters = letters if letters else defaultLetters %}
 
@@ -22,7 +22,7 @@
           {{ letters | safe }}
         </div>
         <div class="logo__symbols logo__symbols--search">
-          UˇᴥˇU
+          U<span class="logo__eye">ˇ</span><span class="logo__nose">ᴥ</span><span class="logo__eye">ˇ</span>U
         </div>
       </div>
     {% endif %}

--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -89,6 +89,10 @@ class Header extends BaseComponent {
     return this.refs.rootElement.classList.contains('header--fixed')
   }
 
+  get isMainPage() {
+    return this.refs.rootElement.classList.contains('header--main')
+  }
+
   get isClosableHeader() {
     const header = this.refs.rootElement
 
@@ -212,7 +216,16 @@ class Header extends BaseComponent {
     const currentScroll = window.scrollY
     const isScrollingDown = currentScroll > lastScroll
     const isHeaderOnTop = currentScroll === 0
+    const mainPageMenuOffset = 30
     this.state.lastScroll = currentScroll
+
+    if (this.isMainPage) {
+      if (this.isMenuOpen && isScrollingDown && currentScroll >= mainPageMenuOffset) {
+        this.closeMenu()
+      } else if (!isScrollingDown && currentScroll < mainPageMenuOffset) {
+        this.openMenu()
+      }
+    }
 
     if (isHeaderOnTop) {
       if (this.isFixed) {

--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -216,13 +216,13 @@ class Header extends BaseComponent {
     const currentScroll = window.scrollY
     const isScrollingDown = currentScroll > lastScroll
     const isHeaderOnTop = currentScroll === 0
-    const mainPageMenuOffset = 30
+    const mainPageMenuOffset = 100
     this.state.lastScroll = currentScroll
 
     if (this.isMainPage) {
       if (this.isMenuOpen && isScrollingDown && currentScroll >= mainPageMenuOffset) {
         this.closeMenu()
-      } else if (!isScrollingDown && currentScroll < mainPageMenuOffset) {
+      } else if (!isScrollingDown && currentScroll < mainPageMenuOffset / 2) {
         this.openMenu()
       }
     }

--- a/src/scripts/modules/logo.js
+++ b/src/scripts/modules/logo.js
@@ -13,9 +13,20 @@ class Logo {
     this.refs = {
       rootElement,
       image: rootElement.querySelector('.logo__image'),
+      symbols: rootElement.querySelector('.logo__symbols'),
     }
 
     this._isAnimation = false
+  }
+
+  setFocusOnElement() {
+    this.refs.symbols.innerHTML =
+      'U<span class="logo__eye">&gt;</span><span class="logo__nose">ᴥ</span><span class="logo__eye">&lt;</span>U'
+  }
+
+  unsetFocusOnElement() {
+    this.refs.symbols.innerHTML =
+      'U<span class="logo__eye">•</span><span class="logo__nose">ᴥ</span><span class="logo__eye">•</span>U'
   }
 
   startAnimation() {

--- a/src/scripts/modules/quick-search.js
+++ b/src/scripts/modules/quick-search.js
@@ -1,4 +1,5 @@
 import BaseComponent from '../core/base-component.js'
+import logo from '../modules/logo.js'
 
 function getBox(element) {
   return element.getBoundingClientRect()
@@ -6,6 +7,14 @@ function getBox(element) {
 
 function clamp(min, value, max) {
   return Math.max(min, Math.min(value, max))
+}
+
+function onFocus() {
+  logo.setFocusOnElement()
+}
+
+function onBlur() {
+  logo.unsetFocusOnElement()
 }
 
 class QuickSearch extends BaseComponent {
@@ -46,6 +55,8 @@ class QuickSearch extends BaseComponent {
       }
     })
     this.refs.input.addEventListener('input', this.onSearch)
+    this.refs.input.addEventListener('focus', onFocus, true)
+    this.refs.input.addEventListener('blur', onBlur, true)
 
     document.addEventListener('keydown', (event) => {
       // Firefox при нажатии Slash открывает свой поиск по странице

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -4,6 +4,14 @@ import BaseComponent from '../core/base-component.js'
 import { MIN_SEARCH_SYMBOLS, SYMBOL_LIMIT, SEARCHABLE_SHORT_WORDS, processHits } from '../core/search-commons.js'
 import logo from '../modules/logo.js'
 
+function onFocus() {
+  logo.setFocusOnElement()
+}
+
+function onBlur() {
+  logo.unsetFocusOnElement()
+}
+
 class Filter extends BaseComponent {
   constructor({ form }) {
     super()
@@ -248,6 +256,8 @@ function init() {
   const debouncedOnFilterChange = debounce(onFilterChange, 150)
 
   function assignSearchField() {
+    searchField.addEventListener('focus', onFocus, true)
+    searchField.addEventListener('blur', onBlur, true)
     searchField.focus()
 
     searchForm.addEventListener('submit', (event) => {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -1,6 +1,6 @@
 .header {
   --header-bg-color: var(--accent-color, var(--color-background));
-  --search-input-height: 1.1em;
+  --search-input-height: 1.5em;
   --header-animation-time: 0.6s;
   position: relative;
   z-index: 1;
@@ -301,7 +301,7 @@
       '.    search-output   .'
       '.    list   .';
     grid-auto-columns: auto 1fr auto;
-    grid-template-rows: 45px auto;
+    grid-template-rows: var(--search-input-height) auto;
   }
 
   .header__inner--menu .header__search {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -74,8 +74,8 @@
   background:
     linear-gradient(
       to bottom,
-      hsla(0 0% 100% / 0.59),
-      hsla(0 0% 100% / 0)
+      hsla(var(--color-base-background) / 0.59),
+      hsla(var(--color-base-background) / 0)
     );
 }
 
@@ -83,8 +83,8 @@
   background:
     linear-gradient(
       to bottom,
-      hsla(0 0% 100% / 0.75),
-      hsla(0 0% 100% / 0.59)
+      hsla(var(--color-base-background) / 0.75),
+      hsla(var(--color-base-background) / 0.59)
     );
 }
 

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -105,7 +105,7 @@
   top: 0;
   left: 0;
   right: 0;
-  padding-top: 7px;
+  padding-top: 13px;
   display: grid;
   align-content: start;
   grid-template-areas:

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -162,6 +162,7 @@
   font-size: calc(var(--font-size-xl) * 0.85);
   line-height: calc(var(--font-line-height-xl) * 0.85);
   letter-spacing: -0.08em;
+  margin-top: var(--gap, 16px);
 }
 
 @media (min-width: 1024px) {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -72,6 +72,10 @@
   font-family: var(--font-family);
 }
 
+.header--main .header__inner--main {
+  height: calc(var(--font-line-height-l) * 1.25);
+}
+
 .header__inner--menu {
   position: fixed;
   z-index: 1;

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -8,7 +8,7 @@
 }
 
 /* фон при открытом меню */
-.header::before {
+.header::before:not(.header--open) {
   content: '';
   position: fixed;
   z-index: 1;

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -65,6 +65,29 @@
   background-color: var(--header-bg-color);
 }
 
+.header.header--main:not(.header--open) {
+  background: none;
+}
+
+.header.header--main:not(.header--open)::after {
+  margin-top: 0;
+  background:
+    linear-gradient(
+      to bottom,
+      hsla(0 0% 100% / 0.59),
+      hsla(0 0% 100% / 0)
+    );
+}
+
+.header.header--main:not(.header--open) .header__inner {
+  background:
+    linear-gradient(
+      to bottom,
+      hsla(0 0% 100% / 0.75),
+      hsla(0 0% 100% / 0.59)
+    );
+}
+
 .header__inner--main {
   font-size: var(--font-size-l);
   letter-spacing: -0.06em;
@@ -224,7 +247,7 @@
   display: none;
 }
 
-.header--simple.header--fixed::after {
+.header--simple:not(.header--main).header--fixed::after {
   border-top: 1px solid;
 }
 

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -276,11 +276,6 @@
     margin-top: 10px;
     flex-basis: 100%;
   }
-
-  .header__inner--main .header__toggle {
-    margin-top: 10px;
-    align-self: flex-start;
-  }
 }
 
 @media (min-width: 768px) {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -278,6 +278,12 @@
   }
 }
 
+@media all and (min-width: 414px) {
+  .header__category.header__category--visible {
+    display: flex;
+  }
+}
+
 @media (min-width: 768px) {
   .header__breadcrumbs {
     font-size: var(--font-size-l);

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -124,6 +124,12 @@
     visibility 0s;
 }
 
+@media (min-width: 1024px) {
+  .header__inner--menu {
+    padding-top: 7px;
+  }
+}
+
 .header__breadcrumbs {
   min-width: 0;
   line-height: 1.25;

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -85,6 +85,7 @@
   top: 0;
   left: 0;
   right: 0;
+  padding-top: 7px;
   display: grid;
   align-content: start;
   grid-template-areas:
@@ -92,9 +93,9 @@
     'search search'
     'search-output search-output'
     'list   list';
-  font-size: var(--font-size-xl);
-  line-height: var(--font-line-height-xl);
-  letter-spacing: var(--letter-spacing);
+  font-size: calc(var(--font-size-xl) * 0.95);
+  line-height: calc(var(--font-line-height-xl) * 0.95);
+  letter-spacing: -0.06em;
   background-color: var(--color-background);
   transition:
     transform var(--header-animation-time) cubic-bezier(0.65, 0.05, 0.36, 1),
@@ -125,7 +126,7 @@
 }
 
 .header__divider--large {
-  font-size: var(--font-size-xl);
+  font-size: calc(var(--font-size-xl) * 0.85);
   line-height: var(--font-line-height-xl);
 }
 
@@ -138,8 +139,8 @@
   margin-top: 12px;
   grid-area: search;
   font-family: var(--font-family);
-  font-size: var(--font-size-xl);
-  line-height: var(--font-line-height-xl);
+  font-size: calc(var(--font-size-xl) * 0.85);
+  line-height: calc(var(--font-line-height-xl) * 0.85);
   letter-spacing: -0.08em;
 }
 

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -124,7 +124,7 @@
 
 .header__logo {
   display: flex;
-  align-self: flex-start;
+  align-self: center;
   align-items: center;
 }
 
@@ -254,6 +254,10 @@
 }
 
 @media not all and (min-width: 1366px) {
+  .header__category--standalone {
+    height: 1.25em;
+  }
+
   .header:not(.header--fixed) .header__category--standalone {
     display: none;
   }

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -263,10 +263,6 @@
   display: none;
 }
 
-.header--simple:not(.header--main).header--fixed::after {
-  border-top: 1px solid;
-}
-
 .header--open {
   z-index: 2;
   animation: none;

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -1,6 +1,6 @@
 .header {
   --header-bg-color: var(--accent-color, var(--color-background));
-  --search-input-height: 1.5em;
+  --search-input-height: 0.7em;
   --header-animation-time: 0.6s;
   position: relative;
   z-index: 1;
@@ -105,7 +105,7 @@
   top: 0;
   left: 0;
   right: 0;
-  padding-top: 13px;
+  padding-top: 20px;
   display: grid;
   align-content: start;
   grid-template-areas:
@@ -122,12 +122,6 @@
     transform var(--header-animation-time) cubic-bezier(0.65, 0.05, 0.36, 1),
     opacity 0s,
     visibility 0s;
-}
-
-@media (min-width: 1024px) {
-  .header__inner--menu {
-    padding-top: 7px;
-  }
 }
 
 .header__breadcrumbs {
@@ -162,7 +156,6 @@
 }
 
 .header__inner--menu .header__search {
-  margin-top: 12px;
   grid-area: search;
   align-self: flex-start;
   font-family: var(--font-family);
@@ -171,10 +164,28 @@
   letter-spacing: -0.08em;
 }
 
+@media (min-width: 1024px) {
+  .header__inner--menu .header__search {
+    margin-top: -14px;
+  }
+}
+
 .header__menu {
   grid-area: list;
   margin-top: var(--gap, 16px);
-  margin-bottom: 2.7%;
+  margin-bottom: 1.7%;
+}
+
+@media (min-width: 1024px) {
+  .header__menu {
+    margin-top: calc(4 * var(--gap, 16px));
+  }
+}
+
+@media (min-width: 1366px) {
+  .header__menu {
+    margin-top: calc(6 * var(--gap, 16px));
+  }
 }
 
 @media not all and (min-width: 768px) {
@@ -212,7 +223,6 @@
   grid-area: button;
   align-self: flex-start;
   margin-left: 20px;
-  margin-top: 5px;
 }
 
 .header--fixed {
@@ -337,15 +347,10 @@
     grid-auto-columns: auto 1fr auto;
     grid-template-rows: var(--search-input-height) auto;
   }
-
-  .header__inner--menu .header__search {
-    margin-top: 0;
-  }
 }
 
 @media (min-width: 1680px) {
   .header__inner--menu {
-    padding-top: 20px;
     padding-bottom: 20px;
   }
 }

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -66,17 +66,10 @@
 }
 
 .header__inner--main {
-  font-size: var(--font-size-m);
+  font-size: var(--font-size-l);
   letter-spacing: -0.06em;
-  line-height: var(--font-line-height-m);
+  line-height: var(--font-line-height-l);
   font-family: var(--font-family);
-}
-
-@media (min-width: 768px) {
-  .header__inner--main {
-    font-size: var(--font-size-l);
-    line-height: var(--font-line-height-l);
-  }
 }
 
 .header__inner--menu {
@@ -93,6 +86,7 @@
     'search search'
     'search-output search-output'
     'list   list';
+  grid-template-rows: var(--font-size-xl) repeat(3, auto);
   font-size: calc(var(--font-size-xl) * 0.95);
   line-height: calc(var(--font-line-height-xl) * 0.95);
   letter-spacing: -0.06em;
@@ -105,8 +99,6 @@
 
 .header__breadcrumbs {
   min-width: 0;
-  font-size: var(--font-size-m);
-  font-family: var(--font-family);
   line-height: 1.25;
 }
 
@@ -132,12 +124,14 @@
 
 .header__logo {
   display: flex;
+  align-self: flex-start;
   align-items: center;
 }
 
 .header__inner--menu .header__search {
   margin-top: 12px;
   grid-area: search;
+  align-self: flex-start;
   font-family: var(--font-family);
   font-size: calc(var(--font-size-xl) * 0.85);
   line-height: calc(var(--font-line-height-xl) * 0.85);
@@ -183,7 +177,9 @@
 
 .header__inner--menu .header__toggle {
   grid-area: button;
+  align-self: flex-start;
   margin-left: 20px;
+  margin-top: 5px;
 }
 
 .header--fixed {
@@ -283,7 +279,7 @@
   }
 
   .header:not(.header--fixed) .header__inner--main .header__logo {
-    font-size: 1.2em;
+    /* font-size: 1.2em; */
   }
 }
 
@@ -304,7 +300,8 @@
       'logo search button'
       '.    search-output   .'
       '.    list   .';
-    grid-auto-columns: auto 1fr 11%;
+    grid-auto-columns: auto 1fr auto;
+    grid-template-rows: 45px auto;
   }
 
   .header__inner--menu .header__search {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -281,10 +281,6 @@
     margin-top: 10px;
     align-self: flex-start;
   }
-
-  .header:not(.header--fixed) .header__inner--main .header__logo {
-    /* font-size: 1.2em; */
-  }
 }
 
 @media (min-width: 768px) {

--- a/src/styles/blocks/logo.css
+++ b/src/styles/blocks/logo.css
@@ -1,6 +1,6 @@
 .logo {
   --ligthness: calc(var(--is-light-theme-on) * 90% + var(--is-dark-theme-on) * 25%);
-  --logo-background-color: hsl(0 0% var(--ligthness));
+  --logo-border-color: hsla(0 0% calc(0% + var(--is-dark-theme-on) * 100%) / 0.33);
   --image-font-size: 0.9375em;
   --logo-letter-spacing: -0.14em;
   --image-padding: calc(2 / 18.75 * 1em) calc(6 / 18.75 * 1em) 0;
@@ -21,7 +21,8 @@
   padding: var(--image-padding);
   display: inline-grid;
   place-items: center;
-  background-color: var(--logo-background-color);
+  border: 1px var(--logo-border-color) solid;
+  background-color: var(--color-background);
   border-radius: 2em;
   pointer-events: none;
   user-select: none;
@@ -87,14 +88,29 @@
 
 .logo__eye {
   position: relative;
-  top: -0.05em;
+  top: -0.08em;
+}
+
+.logo__eye:first-child {
+  letter-spacing: calc(var(--logo-letter-spacing) * 2);
+}
+
+.logo__nose {
+  position: relative;
+  font-size: calc(var(--image-font-size) * 10 / 7);
+  line-height: calc(var(--image-font-size) * 7 / 10);
+  top: -0.015em;
+  letter-spacing: calc(var(--logo-letter-spacing) * 1.5);
 }
 
 .logo__text {
-  --stroke-width: 2px;
-  margin-left: 6px;
-  align-self: baseline;
-  text-underline-offset: 0.2em;
+  margin-left: 5px;
+  padding: 0 calc(var(--logo-letter-spacing) * -15 / 7);
+  background-color: var(--color-background);
+  border: 1px var(--logo-border-color) solid;
+  border-radius: 2em;
+  text-decoration: none;
+  line-height: calc(var(--image-font-size) * 7 / 10 + var(--logo-letter-spacing) * -22 / 7);
 }
 
 .logo__text::first-letter {

--- a/src/styles/blocks/logo.css
+++ b/src/styles/blocks/logo.css
@@ -21,11 +21,14 @@
   padding: var(--image-padding);
   display: inline-grid;
   place-items: center;
-  border: 1px var(--logo-border-color) solid;
   background-color: var(--color-background);
   border-radius: 2em;
   pointer-events: none;
   user-select: none;
+}
+
+.logo__image--contrast {
+  border: 1px var(--logo-border-color) solid;
 }
 
 .logo__image::before {
@@ -107,10 +110,13 @@
   margin-left: 5px;
   padding: 0 calc(var(--logo-letter-spacing) * -15 / 7);
   background-color: var(--color-background);
-  border: 1px var(--logo-border-color) solid;
   border-radius: 2em;
   text-decoration: none;
   line-height: calc(var(--image-font-size) * 7 / 10 + var(--logo-letter-spacing) * -22 / 7);
+}
+
+.logo__text--contrast {
+  border: 1px var(--logo-border-color) solid;
 }
 
 .logo__text::first-letter {

--- a/src/styles/blocks/logo.css
+++ b/src/styles/blocks/logo.css
@@ -1,9 +1,9 @@
 .logo {
   --ligthness: calc(var(--is-light-theme-on) * 90% + var(--is-dark-theme-on) * 25%);
   --logo-border-color: hsla(0 0% calc(0% + var(--is-dark-theme-on) * 100%) / 0.33);
-  --image-font-size: 0.9375em;
+  --image-font-size: 0.85em;
   --logo-letter-spacing: -0.14em;
-  --image-padding: calc(2 / 18.75 * 1em) calc(6 / 18.75 * 1em) 0;
+  --image-padding: calc(1 / 15 * 1em) calc(4 / 15 * 1em) 0;
   display: inline-flex;
   white-space: nowrap;
   text-decoration: none;
@@ -22,6 +22,7 @@
   display: inline-grid;
   place-items: center;
   background-color: var(--color-background);
+  border: 1px transparent solid;
   border-radius: 2em;
   pointer-events: none;
   user-select: none;
@@ -108,15 +109,20 @@
 
 .logo__text {
   margin-left: 5px;
-  padding: 0 calc(var(--logo-letter-spacing) * -15 / 7);
+  padding: var(--image-padding);
+  padding-top: calc(2 / 15 * 1em);
+  padding-bottom: calc(1 / 10 * 1em);
   background-color: var(--color-background);
   border-radius: 2em;
+  border: 1px transparent solid;
   text-decoration: none;
-  line-height: calc(var(--image-font-size) * 7 / 10 + var(--logo-letter-spacing) * -22 / 7);
+  font-size: var(--image-font-size);
+  line-height: var(--image-font-size);
 }
 
 .logo__text--contrast {
   border: 1px var(--logo-border-color) solid;
+  padding-bottom: 0;
 }
 
 .logo__text::first-letter {

--- a/src/styles/blocks/logo.css
+++ b/src/styles/blocks/logo.css
@@ -3,7 +3,7 @@
   --logo-border-color: hsla(0 0% calc(0% + var(--is-dark-theme-on) * 100%) / 0.33);
   --image-font-size: 0.85em;
   --logo-letter-spacing: -0.14em;
-  --image-padding: calc(1 / 15 * 1em) calc(4 / 15 * 1em) 0;
+  --image-padding: calc(1 / 15 * 1em) calc(5 / 15 * 1em) 0;
   display: inline-flex;
   white-space: nowrap;
   text-decoration: none;

--- a/src/styles/blocks/menu-toggle.css
+++ b/src/styles/blocks/menu-toggle.css
@@ -22,8 +22,10 @@
   align-items: center;
 }
 
-.menu-toggle__inner--close {
-  flex-direction: column-reverse;
+@media all and (min-width: 1024px) {
+  .menu-toggle__inner--close {
+    flex-direction: column-reverse;
+  }
 }
 
 .menu-toggle__icon {

--- a/src/styles/blocks/menu-toggle.css
+++ b/src/styles/blocks/menu-toggle.css
@@ -22,6 +22,10 @@
   align-items: center;
 }
 
+.menu-toggle__inner--close {
+  flex-direction: column-reverse;
+}
+
 .menu-toggle__icon {
   transition: opacity 0.2s;
 }

--- a/src/styles/blocks/nav-list.css
+++ b/src/styles/blocks/nav-list.css
@@ -44,6 +44,7 @@
 .nav-list__link-text {
   position: relative;
   display: block;
+  letter-spacing: var(--letter-spacing);
 }
 
 .nav-list__link-text::after {

--- a/src/styles/blocks/search-page.css
+++ b/src/styles/blocks/search-page.css
@@ -7,7 +7,6 @@
   --search-input-height: 1.285em;
   position: sticky;
   top: 0;
-  border-bottom: 1px solid;
 }
 
 .search-page__header-inner {

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -43,7 +43,7 @@
 }
 
 .search__input::placeholder {
-  opacity: 0.6;
+  opacity: 0.7;
   font: inherit;
   letter-spacing: inherit;
   color: inherit;

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -2,8 +2,8 @@
   position: relative;
   display: grid;
   font-family: var(--font-family);
-  font-size: var(--font-size-l);
-  line-height: var(--font-line-height-l);
+  font-size: calc(var(--font-size-xl) * 0.85);
+  line-height: calc(var(--font-line-height-xl) * 0.85);
   letter-spacing: var(--letter-spacing);
 }
 
@@ -24,8 +24,12 @@
   font: inherit;
   letter-spacing: inherit;
   color: inherit;
-  border-radius: 6px;
-  background-color: hsl(0 0% 77% / 0.33);
+  outline: none;
+  border-bottom: 2px solid hsl(0 0% 70%);
+}
+
+.search__input:focus {
+  border-bottom-color: hsl(0 0% 0%);
 }
 
 .search__control {

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -27,10 +27,11 @@
   color: inherit;
   outline: none;
   border-bottom: 2px solid hsl(0 0% 70%);
+  background-color: transparent;
 }
 
 .search__input:focus {
-  border-bottom-color: hsl(0 0% 0%);
+  border-bottom-color: var(--color-text);
 }
 
 .search__control {

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -19,7 +19,6 @@
   display: block;
   box-sizing: border-box;
   width: 100%;
-  height: var(--search-input-height, 45px);
   border: 0;
   padding: 0 10px;
   font: inherit;

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -1,4 +1,5 @@
 .search {
+  --search-input-height: calc(var(--font-size-xl) * 1.25);
   position: relative;
   display: grid;
   font-family: var(--font-family);
@@ -18,7 +19,7 @@
   display: block;
   box-sizing: border-box;
   width: 100%;
-  height: var(--search-input-height, 1.25em);
+  height: var(--search-input-height, 45px);
   border: 0;
   padding: 0 10px;
   font: inherit;

--- a/src/views/404.njk
+++ b/src/views/404.njk
@@ -7,7 +7,9 @@
   <div class="not-found font-theme font-theme--code">
     <div class="not-found__logo logo">
       <div class="logo__image" aria-hidden="true">
-        <div class="logo__symbols">U×ᴥ×U</div>
+        <div class="logo__symbols">
+          U<span class="logo__eye">×</span><span class="logo__nose">ᴥ</span><span class="logo__eye">×</span>U
+        </div>
       </div>
     </div>
     <p class="not-found__description">

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -4,11 +4,12 @@
 {% set isLogoContrastColor = hasCategory %}
 
 {{ header(
-  isLogoContrastColor=isLogoContrastColor
+  isLogoContrastColor=isLogoContrastColor,
+  isMainPage=true
 ) }}
 
 <main>
-  <div class="container" style="margin-top: calc({{ collections.articleIndexes.length }} * var(--font-size-xxl));">
+  <div class="container" style="margin-top: calc({{ collections.articleIndexes.length }} * var(--font-size-xxl) * 1.25);">
     <div class="intro">
       <h1 class="visually-hidden">Дока</h1>
       <p class="intro__description">Документация для разработчиков на человеческом языке</p>

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -9,7 +9,7 @@
 ) }}
 
 <main>
-  <div class="container" style="margin-top: calc({{ collections.articleIndexes.length }} * var(--font-size-xxl));">
+  <div class="container" style="margin-top: calc(({{ collections.articleIndexes.length }} + 1.5) * var(--font-size-xxl));">
     <div class="intro">
       <h1 class="visually-hidden">Дока</h1>
       <p class="intro__description">Документация для разработчиков на человеческом языке</p>

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -4,12 +4,11 @@
 {% set isLogoContrastColor = hasCategory %}
 
 {{ header(
-  isStatic=true,
   isLogoContrastColor=isLogoContrastColor
 ) }}
 
 <main>
-  <div class="container">
+  <div class="container" style="margin-top: calc({{ collections.articleIndexes.length }} * var(--font-size-xxl));">
     <div class="intro">
       <h1 class="visually-hidden">Дока</h1>
       <p class="intro__description">Документация для разработчиков на человеческом языке</p>

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -9,7 +9,7 @@
 ) }}
 
 <main>
-  <div class="container" style="margin-top: calc({{ collections.articleIndexes.length }} * var(--font-size-xxl) * 1.25);">
+  <div class="container" style="margin-top: calc({{ collections.articleIndexes.length }} * var(--font-size-xxl));">
     <div class="intro">
       <h1 class="visually-hidden">Дока</h1>
       <p class="intro__description">Документация для разработчиков на человеческом языке</p>

--- a/src/views/people.njk
+++ b/src/views/people.njk
@@ -20,9 +20,9 @@
 
 <div class="people-page">
   {{ header(
-    category=title,
     pageCategoryId='people',
-    title=title
+    category=title,
+    isCategoryVisible=true
   ) }}
 
   <main class="people-page__main">

--- a/src/views/person.njk
+++ b/src/views/person.njk
@@ -43,9 +43,10 @@
 
 <div class="person-page">
   {{ header(
-    category=categoryName,
     pageCategoryId='people',
-    title=name
+    category=categoryName,
+    title=name,
+    isCategoryVisible=true
   ) }}
 
   <main class="person-page__main">

--- a/src/views/views.11tydata.js
+++ b/src/views/views.11tydata.js
@@ -285,7 +285,7 @@ module.exports = {
 
       switch (pageUrl) {
         case '/licenses/':
-          return 'U©ᴥ©U'
+          return 'U<span class="logo__eye">©</span><span class="logo__nose">ᴥ</span><span class="logo__eye">©</span>U'
         default:
           return null
       }


### PR DESCRIPTION
В соответствии с новым дизайном необходимо изменить логотип, хлебные крошки, размеры всего и работу меню для главной страницы:

<img width="601" alt="Screenshot 2022-07-09 at 18 08 23" src="https://user-images.githubusercontent.com/13916521/178111599-441aa22c-f371-4639-9183-a717d6096f52.png">

<img width="605" alt="Screenshot 2022-07-09 at 18 08 30" src="https://user-images.githubusercontent.com/13916521/178111605-5bbd3ae9-98f7-4b12-a633-016ff7deed63.png">

<img width="604" alt="Screenshot 2022-07-09 at 18 08 40" src="https://user-images.githubusercontent.com/13916521/178111613-4299a158-5026-4bb0-8bdf-0a2ee3da92cf.png">

Предлагаю обсудить градиенты, которые мы в итоге убрали... Стоит ли к ним возвращаться?

Ещё есть моменты с развёрнутым поиском на мобильном...

Было задумано так:

<img width="311" alt="Screenshot 2022-07-09 at 18 09 46" src="https://user-images.githubusercontent.com/13916521/178111625-c4fc7590-983c-489f-82ce-e9e0ce0df929.png">

Сделал так на обсуждение:

<img width="311" alt="Screenshot from iPhone" src="https://user-images.githubusercontent.com/13916521/178111628-80ac078c-9da7-4ef5-a717-b7f0afb892f7.png">