### PR TITLE
Чинит заголовок карточки рекомендаций

### DIFF
--- a/src/styles/blocks/featured-article.css
+++ b/src/styles/blocks/featured-article.css
@@ -56,6 +56,8 @@
   font-size: var(--font-size);
   line-height: var(--line-height);
   font-weight: normal;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .featured-article__code {


### PR DESCRIPTION
Этот пулл реквест обрезает текст троеточием, если заголовок слишком длинный и не влезает в карточку. #965