### PR TITLE
Предлагает решение проблемы артефактов в активных кнопках-фильтрах поиска

### DIFF
--- a/src/styles/blocks/tag-filter.css
+++ b/src/styles/blocks/tag-filter.css
@@ -21,12 +21,12 @@
 }
 
 .tag-filter__text {
+  box-shadow: 0 0 1px 1px var(--tag-filter-color);
   position: relative;
   z-index: 0;
   display: block;
   overflow: hidden;
   padding: 2px 8px;
-  border: 2px solid var(--tag-filter-color);
   line-height: 1;
   text-align: center;
   border-radius: 2em;


### PR DESCRIPTION
Closes #971

Было: 

![doka_bag-issue](https://user-images.githubusercontent.com/106589280/186253743-025f64ce-225a-4228-9de8-a1cab820ef4e.png)

Стало:

![doka_bag-issue_fix](https://user-images.githubusercontent.com/106589280/186253923-13e05241-c7b5-4453-a43b-273ad1f5b453.png)

Решение:

Добавил вместо бордера `box-shadow`. Он создаёт приятный мягкий переход и скрывает артефакт на любом масштабе.

