### PR TITLE
Упрощает стиль переключателя фильтра поиска

### DIFF
--- a/src/styles/blocks/switch.css
+++ b/src/styles/blocks/switch.css
@@ -71,3 +71,10 @@
       var(--is-dark-theme-on) * 0.12
     );
 }
+
+.switch:focus-within {
+  outline: auto 2px Highlight;
+  outline: auto 2px -webkit-focus-ring-color;
+  outline-offset: 2px;
+  border-radius: 6px;
+}

--- a/src/styles/blocks/switch.css
+++ b/src/styles/blocks/switch.css
@@ -71,9 +71,3 @@
       var(--is-dark-theme-on) * 0.12
     );
 }
-
-.switch:focus-within {
-  outline: 2px solid hsl(var(--color-blue) / 0.7);
-  outline-offset: 2px;
-  border-radius: 6px;
-}


### PR DESCRIPTION
Привет! 

На странице поиска обратил внимание на переключатель фильтра поиска в нижнем левом углу экрана. При фокусе внутри там активируется псевдокласс `:focus-within` с голубым `outline`. 

При этом в целом на странице такого больше нет, только на этом переключателе. У других кнопочек стандартная чёрная обводка.

Предложение такое: можно убрать этот голубой `outline`, потому что и код будет проще, и не бьётся он с другими элементами, и его практическая польза неясна.

Было: 

![switch__before](https://user-images.githubusercontent.com/106589280/186879835-39d3fa38-2f14-42c5-a7ec-9d45141a234a.png)

Станет:

![switch__after](https://user-images.githubusercontent.com/106589280/186879873-6edffa1d-7a03-4f90-883a-aa31724e22a8.png)

