### PR TITLE
Изменяет переносы слов-названий методов в тексте

### DIFF
--- a/src/transforms/code-breakify-transform.js
+++ b/src/transforms/code-breakify-transform.js
@@ -1,6 +1,22 @@
 function breakify(content) {
   const symbols = ['.', ',', '-', '_', '=', ':', '~', '/', '\\', '?', '#', '%', '(', ')', '[', ']']
 
+  if (/[A-Z]/g.test(content)) {
+    switch (true) {
+      case /^[^A-Z]/.test(content):
+        content = content.replaceAll(/[A-Z]/g, (match) => `<wbr>${match}`)
+        break
+      case /[A-Z]{2,}/.test(content):
+        content = content.replaceAll(/[A-Z][a-z]+/g, (match) => `<wbr>${match}`)
+        break
+      case /[A-Z][a-z.]+[A-Z][a-z()]+/.test(content):
+        content = content.replaceAll(/[A-Z][a-z()]+$/g, (match) => `<wbr>${match}`)
+        break
+      default:
+        break
+    }
+  }
+
   for (const symbol of symbols) {
     content = content.replaceAll(symbol, (match) => `<wbr>${match}<wbr>`)
   }


### PR DESCRIPTION
Привет снова!

Заметил, что некоторые названия методов, по типу `.addEventListener()`, разбиваются в тексте только по спецсимволам, из-за чего возникают такие вот пустоты: 

![before](https://user-images.githubusercontent.com/106589280/189499098-1362f4a7-cb34-489f-ac44-d3a1342ec90e.png)

На мой взгляд, выглядит странно: точка остаётся на одной строке, а остальной текст улетает на следующую, плюс разрезается фон и получается, словно что-то «оторвали». И чем длиннее название метода, например `.getElementsByClassName()`, тем больше эта пустота.

Что, если добавить в функцию небольшую возможность разбивать подобные названия? Поскольку методы из нескольких слов, каждое из которых начинается с заглавной буквы, предложил бы такую логику:

- Если в слове есть заглавные буквы, то:

1. Если НЕ начинается на заглавную, то вставить `<wbr>` перед каждой заглавной;
`.addEventListener() => <wbr>.<wbr>add<wbr>Event<wbr>Listener<wbr>(<wbr><wbr>)<wbr>`

2. Если начинается с двух и более заглавных подряд, то вставить `<wbr>` только перед сочетанием заглавной и последующих букв в нижнем регистре;
`HTMLCollection => HTML<wbr>Collection`

3. Если чередуется сочетание заглавной и букв в нижнем регистре, то вставить `<wbr>` со второй пары;
`FormData => Form<wbr>Data`

4. В остальных случаях не трогать.
`Element => Element`
`submit => submit`

- Если заглавных нет, то не трогать.

Получается так:

![after](https://user-images.githubusercontent.com/106589280/189499651-a884d181-a1bf-4019-8486-6f2889ce34dc.png)

Выглядит вроде лучше, код прикладываю 😅