### PR TITLE
Правит баг с блоками `HTTP` кода

### DIFF
--- a/src/styles/blocks/block-code.css
+++ b/src/styles/blocks/block-code.css
@@ -34,7 +34,7 @@
   align-content: start;
   grid-template-columns: auto minmax(0, 1fr);
   grid-template-areas: 'lines code';
-  overflow: auto hidden;
+  overflow: auto;
   overscroll-behavior-x: contain;
   font-size: 1em;
   line-height: var(--line-height);
@@ -87,7 +87,6 @@
 
 .block-code__highlight {
   white-space: pre;
-  z-index: 0;
 }
 
 .block-code__tools {

--- a/src/styles/blocks/block-code.css
+++ b/src/styles/blocks/block-code.css
@@ -34,7 +34,7 @@
   align-content: start;
   grid-template-columns: auto minmax(0, 1fr);
   grid-template-areas: 'lines code';
-  overflow: auto;
+  overflow: auto hidden;
   overscroll-behavior-x: contain;
   font-size: 1em;
   line-height: var(--line-height);
@@ -87,6 +87,7 @@
 
 .block-code__highlight {
   white-space: pre;
+  z-index: 0;
 }
 
 .block-code__tools {

--- a/src/transforms/article-code-blocks-transform.js
+++ b/src/transforms/article-code-blocks-transform.js
@@ -16,7 +16,13 @@ function renderOriginalLine(line) {
 }
 
 function highlightCode(source, language) {
-  return Prism.highlight(source, Prism.languages[language], language)
+  const highlightResult = Prism.highlight(source, Prism.languages[language], language)
+
+  if (language === 'http') {
+    return highlightResult.replaceAll('header', 'http')
+  }
+
+  return highlightResult
 }
 
 // подсветка синтаксиса,


### PR DESCRIPTION
Fix #987

Предлагаю добавить `z-index`, чтобы явно определить место для блоков кода под шапкой. Также спрятать вертикальную прокрутку через `overflow` . Все строчки кода нумеруются и под них растягивается контейнер, так что прокрутка по вертикали им и так вроде не нужна 🐨

Было: 

![image](https://user-images.githubusercontent.com/106589280/192148924-ecc1f174-29ec-47cf-8e52-47737c85d6b9.png)


Стало:

![image](https://user-images.githubusercontent.com/106589280/192148945-6f086f7a-d818-432a-828e-01487e169fcb.png)


Было:

![image](https://user-images.githubusercontent.com/106589280/192148966-8042eed8-7d0d-463e-9e6f-1d50195e4d4c.png)


Стало:

![image](https://user-images.githubusercontent.com/106589280/192148980-ecb7208a-5c28-4e0c-a435-12a67c82395b.png)
