### PR TITLE
Добавляет превью цвета в блоках кода

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,7 @@ const headingsIdTransform = require('./src/transforms/headings-id-transform')
 const headingsAnchorTransform = require('./src/transforms/headings-anchor-transform')
 const articleCodeBlocksTransform = require('./src/transforms/article-code-blocks-transform')
 const articleInlineCodeTransform = require('./src/transforms/article-inline-code-transform')
+const colorPickerTransform = require('./src/transforms/color-picker-transform')
 const codeClassesTransform = require('./src/transforms/code-classes-transform')
 const codeBreakifyTransform = require('./src/transforms/code-breakify-transform')
 const tocTransform = require('./src/transforms/toc-transform')
@@ -287,6 +288,7 @@ module.exports = function (config) {
       linkTransform,
       articleCodeBlocksTransform,
       articleInlineCodeTransform,
+      colorPickerTransform,
       codeClassesTransform,
       codeBreakifyTransform,
       iframeAttrTransform,

--- a/src/styles/blocks/color-picker.css
+++ b/src/styles/blocks/color-picker.css
@@ -5,6 +5,7 @@
   height: 10px;
   margin: var(--color-picker-margin);
   background-color: var(--color-picker);
+  line-height: 0;
 }
 
 .color-picker__internal {

--- a/src/styles/blocks/color-picker.css
+++ b/src/styles/blocks/color-picker.css
@@ -1,0 +1,16 @@
+.token.color::before {
+  content: "";
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin: var(--color-picker-margin);
+  background-color: var(--color-picker);
+}
+
+.color-picker__internal {
+  --color-picker-margin: 0 2px;
+}
+
+.color-picker__external {
+  --color-picker-margin: 0 2px 0 0;
+}

--- a/src/styles/code-dark-theme.css
+++ b/src/styles/code-dark-theme.css
@@ -142,6 +142,11 @@ pre[class*="language-"] {
   color: hsl(187, 47%, 55%);
 }
 
+/* Color-picker */
+.token.color::before {
+  border: 1px solid #fff;
+}
+
 /* HTML overrides */
 .token.attr-value > .token.punctuation.attr-equals,
 .token.special-attr > .token.attr-value > .token.value.css {

--- a/src/styles/code-light-theme.css
+++ b/src/styles/code-light-theme.css
@@ -131,6 +131,11 @@ pre[class*="language-"] {
   color: hsl(198, 99%, 37%);
 }
 
+/* Color-picker */
+.token.color::before {
+  border: 1px solid hsl(230, 8%, 24%);
+}
+
 /* HTML overrides */
 .token.attr-value > .token.punctuation.attr-equals,
 .token.special-attr > .token.attr-value > .token.value.css {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -81,3 +81,4 @@
 @import 'blocks/linked-article.css';
 @import 'blocks/related-articles-list.css';
 @import 'blocks/code-fix.css';
+@import 'blocks/color-picker.css';

--- a/src/transforms/color-picker-transform.js
+++ b/src/transforms/color-picker-transform.js
@@ -1,0 +1,17 @@
+/**
+ * @param {Window} window
+ */
+module.exports = function (window) {
+  const content = window.document.querySelector('.article__content-inner')
+  const color = content?.querySelectorAll('.token.color')
+
+  color?.forEach(function (item) {
+    item.style.setProperty('--color-picker', ` ${item.textContent}`)
+
+    if (/[(]/.test(item.previousElementSibling.textContent)) {
+      item.classList.add('color-picker__internal') // Добавляет дополнительный margin слева, если токен цвета внутри скобок
+    } else {
+      item.classList.add('color-picker__external')
+    }
+  })
+}


### PR DESCRIPTION
Появилась идея, как можно было бы решить #895 без обилия кода.

Prism уже разметил цвета в блоках с кодом, и я подумал, что можно воспользоваться этим и добавить фичу с превью цвета.

Получается так:

![в скобках](https://user-images.githubusercontent.com/106589280/194746479-d4ec6a06-220f-4b25-8614-debf905a6493.png)

Тёмная тема:

![тёмная тема](https://user-images.githubusercontent.com/106589280/194746487-fe150c50-8fd0-42ee-b925-788305c9de4f.png)

![построчно](https://user-images.githubusercontent.com/106589280/194746502-255ed144-42d5-4406-ad75-4ebadd697130.png)

![другое](https://user-images.githubusercontent.com/106589280/194746524-d588d4e5-45dd-4550-b1bc-63830aeaf225.png)

Из ошибок нашёл две. Первая здесь:

![ошибка-1](https://user-images.githubusercontent.com/106589280/194746543-a34d3433-4dd2-4f4b-8a14-4fad55fda406.png)

Цвет не отображается, но это можно решить обновлением зависимости, в [последней версии](https://www.npmjs.com/package/prismjs) `RebeccaPurple` [добавлен](https://github.com/PrismJS/prism/pull/3448).

Вторая:

![ошибка-2](https://user-images.githubusercontent.com/106589280/194747150-a3cedb07-ceab-4cb6-b4fc-9d1a7238c5d6.png)

Связано с тем, что у призма пока нет поддержки рэгэкспами нового синтаксиса из примеров, только старого, но, мне кажется, это дело времени, плюс я закинул в их репозиторий предложение такую поддержку добавить дабы посильно ускорить процесс. Можно и обработать эти «непрокрасы» отдельно в коде.

В остальном вроде выглядит интересно 🤔🙂

![image](https://user-images.githubusercontent.com/106589280/194747283-3d13377b-3689-4b2f-913a-acf7cf684fb8.png)

