### PR TITLE
Правит переносы имён методов

### DIFF
--- a/src/transforms/code-breakify-transform.js
+++ b/src/transforms/code-breakify-transform.js
@@ -17,6 +17,7 @@ function breakify(content) {
         break
     }
   }
+
   // Расстановка переносов по спецсимволам
   for (const symbol of symbols) {
     const startsWithSymbol = new RegExp(`^[\\${symbol}]`, '')

--- a/src/transforms/code-breakify-transform.js
+++ b/src/transforms/code-breakify-transform.js
@@ -20,14 +20,13 @@ function breakify(content) {
 
   // Расстановка переносов по спецсимволам
   for (const symbol of symbols) {
-    const startsWithSymbol = new RegExp(`^[\\${symbol}]`, '')
     const firstSymbolWithinTags = new RegExp(`^(<wbr>)[\\${symbol}](<wbr>)`, '')
 
-    if (!startsWithSymbol.test(content)) {
-      content = content.replaceAll(symbol, `<wbr>${symbol}<wbr>`)
-    } else {
-      // Исключение для переносов первого спецсимвола в слове
-      content = content.replaceAll(symbol, `<wbr>${symbol}<wbr>`).replace(firstSymbolWithinTags, `${symbol}`)
+    content = content.replaceAll(symbol, `<wbr>${symbol}<wbr>`)
+
+    // Исключение для переносов первого спецсимвола в слове
+    if (firstSymbolWithinTags.test(content)) {
+      content = content.replace(firstSymbolWithinTags, `${symbol}`)
     }
   }
 

--- a/src/transforms/code-breakify-transform.js
+++ b/src/transforms/code-breakify-transform.js
@@ -1,6 +1,7 @@
 function breakify(content) {
   const symbols = ['.', ',', '-', '_', '=', ':', '~', '/', '\\', '?', '#', '%', '(', ')', '[', ']']
 
+  // Расстановка переносов между частями слова
   if (/[A-Z]/g.test(content)) {
     switch (true) {
       case /^[^A-Z]/.test(content):
@@ -16,9 +17,17 @@ function breakify(content) {
         break
     }
   }
-
+  // Расстановка переносов по спецсимволам
   for (const symbol of symbols) {
-    content = content.replaceAll(symbol, (match) => `<wbr>${match}<wbr>`)
+    const startsWithSymbol = new RegExp(`^[\\${symbol}]`, '')
+    const firstSymbolWithinTags = new RegExp(`^(<wbr>)[\\${symbol}](<wbr>)`, '')
+
+    if (!startsWithSymbol.test(content)) {
+      content = content.replaceAll(symbol, `<wbr>${symbol}<wbr>`)
+    } else {
+      // Исключение для переносов первого спецсимвола в слове
+      content = content.replaceAll(symbol, `<wbr>${symbol}<wbr>`).replace(firstSymbolWithinTags, `${symbol}`)
+    }
   }
 
   return content


### PR DESCRIPTION
Fix #992

Сделал так, чтобы переносы не ставились для первых спецсимволов в коде. 

Было:

![image](https://user-images.githubusercontent.com/106589280/195050066-6248766d-3b5d-42dd-b88b-459bed29c4dc.png)

Стало:

![image](https://user-images.githubusercontent.com/106589280/195050120-18a44c06-74a8-4273-a2be-b20111f95610.png)

Также добавил тройку комментов по коду, чтобы другим было легче разобраться 🙂