### PR TITLE
Приводит названия к единому шаблону

### DIFF
--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -8,6 +8,15 @@ module.exports = () => {
     linkify: true,
     highlight: function (str, lang) {
       const content = md.utils.escapeHtml(str)
+      const LANG_ALIASES = {
+        javascript: 'js',
+        nginxconf: 'nginx',
+      }
+
+      if (lang in LANG_ALIASES) {
+        lang = LANG_ALIASES[lang]
+      }
+
       return lang ? `<pre data-lang='${lang}'><code>${content}</code></pre>` : `<pre>${content}</pre>`
     },
   })

--- a/src/transforms/article-code-blocks-transform.js
+++ b/src/transforms/article-code-blocks-transform.js
@@ -6,11 +6,6 @@ loadLanguages()
 
 const endOfLine = '\n'
 
-const LANG_ALIASES = {
-  js: 'javascript',
-  nginxconf: 'nginx',
-}
-
 function renderOriginalLine(line) {
   return `<span class="block-code__original-line">${escape(line)}</span>`
 }
@@ -31,7 +26,6 @@ module.exports = function (window) {
     const codeElement = preElement.querySelector('code')
 
     let language = (preElement.getAttribute('data-lang') || '').trim().toLowerCase()
-    language = LANG_ALIASES[language] || language
 
     const originalContent = codeElement.textContent
     const highlightedContent = language ? highlightCode(originalContent, language) : originalContent


### PR DESCRIPTION
Есть предложение привести названия, вроде `JS` или `JavaScript`, к единому шаблону.

Сейчас то так:

![image](https://user-images.githubusercontent.com/106589280/195348007-c8b80efb-e031-4cc2-a67c-c8e3e59f64ad.png)

То так:

![image](https://user-images.githubusercontent.com/106589280/195348065-66b097d1-e796-41dc-981e-1bdc6145377a.png)

В `src/transforms/article-code-blocks-transform.js` из-за этой путаницы даже есть код, который подглядывает в объект `LANG_ALIASES` в поисках понятной призму записи.

Можно перенести эти исключения из `article-code-blocks-transform` в `src/markdown-it.js` и шаблонизировать названия до того, как вставлять их в атрибут `data-lang`. 

Плюсы: 

1. Можно убрать лишнюю проверку из `article-code-blocks-transform`, поскольку туда всё будет попадать уже шаблонизированным;
2. Везде будет одинаковая запись названий;
3. Авторам не придётся менять `JavaScript` на `JS` или что-то такое. Как хотят, так и пишут, код всё приведёт к единому стилю.

Было:

![image](https://user-images.githubusercontent.com/106589280/195348920-0e90e89d-9d1d-4432-b052-24898dd57ba4.png)


Стало:

![image](https://user-images.githubusercontent.com/106589280/195348982-d3c50c73-44c4-4327-97a2-109bf432728e.png)

На мой взгляд, так больше порядка 😀
