### PR TITLE
Оставляет только один тип карточки для Твиттера

### DIFF
--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -78,7 +78,7 @@
 
 <!-- 10.2 Twitter -->
 
-<meta property="twitter:card" content="summary_large_image">
+<meta property="twitter:card" content="summary">
 <meta property="twitter:url" content="{{ fullPageUrl }}">
 <meta property="twitter:title" content="{{ socialTitle }}">
 
@@ -87,7 +87,6 @@
 {% endif %}
 
 <meta property="twitter:image" content="{{ defaultOpenGraphPath }}">
-<meta property="twitter:card" content="summary">
 <meta property="twitter:site" content="@doka_guide">
 
 <!-- 10.3 Microdata -->

--- a/src/includes/meta.njk
+++ b/src/includes/meta.njk
@@ -78,7 +78,7 @@
 
 <!-- 10.2 Twitter -->
 
-<meta property="twitter:card" content="summary">
+<meta property="twitter:card" content="summary_large_image">
 <meta property="twitter:url" content="{{ fullPageUrl }}">
 <meta property="twitter:title" content="{{ socialTitle }}">
 


### PR DESCRIPTION
[По документации](https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started)

> twitter:card
> The card type, which will be one of “summary”, “summary_large_image”, “app”, or “player”.

Сейчас Твиттер находит тип карточки `summary_large_image`, потом находит просто `summary`, забывает первый тип и использует последний. Опытным путём кажется, что `summary_large_image` всё же лучше.