### PR TITLE
Правит ошибки превью цвета в блоках кода

### DIFF
--- a/src/styles/blocks/color-picker.css
+++ b/src/styles/blocks/color-picker.css
@@ -3,15 +3,15 @@
   display: inline-block;
   width: 10px;
   height: 10px;
-  margin: var(--indent);
+  margin: var(--color-picker-margin);
   background-color: var(--color-picker);
   line-height: 0;
 }
 
-.indent {
-  --indent: 0 2px 0 0;
+.color-picker__inline {
+  --color-picker-margin: 0 2px 0 0;
 }
 
-.parenthesis-indent {
+.color-picker__grouped {
   margin-right: 2px;
 }

--- a/src/styles/blocks/color-picker.css
+++ b/src/styles/blocks/color-picker.css
@@ -3,15 +3,15 @@
   display: inline-block;
   width: 10px;
   height: 10px;
-  margin: var(--color-picker-margin);
+  margin: var(--indent);
   background-color: var(--color-picker);
   line-height: 0;
 }
 
-.color-picker__internal {
-  --color-picker-margin: 0 2px;
+.indent {
+  --indent: 0 2px 0 0;
 }
 
-.color-picker__external {
-  --color-picker-margin: 0 2px 0 0;
+.parenthesis-indent {
+  margin-right: 2px;
 }

--- a/src/transforms/color-picker-transform.js
+++ b/src/transforms/color-picker-transform.js
@@ -6,12 +6,15 @@ module.exports = function (window) {
   const color = content?.querySelectorAll('.token.color')
 
   color?.forEach(function (item) {
+    if (/(transparent)/.test(item.textContent)) {
+      return item.classList.replace('color', 'color-transparent') // Выключает color-picker для цвета transparent
+    }
+
     item.style.setProperty('--color-picker', ` ${item.textContent}`)
+    item.classList.add('indent')
 
     if (/[(]/.test(item.previousElementSibling.textContent)) {
-      item.classList.add('color-picker__internal') // Добавляет дополнительный margin слева, если токен цвета внутри скобок
-    } else {
-      item.classList.add('color-picker__external')
+      item.previousElementSibling.classList.add('parenthesis-indent') // Добавляет дополнительный margin скобке, если затем следует токен цвета
     }
   })
 }

--- a/src/transforms/color-picker-transform.js
+++ b/src/transforms/color-picker-transform.js
@@ -11,10 +11,10 @@ module.exports = function (window) {
     }
 
     item.style.setProperty('--color-picker', ` ${item.textContent}`)
-    item.classList.add('indent')
+    item.classList.add('color-picker__inline')
 
     if (/[(]/.test(item.previousElementSibling.textContent)) {
-      item.previousElementSibling.classList.add('parenthesis-indent') // Добавляет дополнительный margin скобке, если затем следует токен цвета
+      item.previousElementSibling.classList.add('color-picker__grouped') // Добавляет дополнительный margin скобке, если затем следует токен цвета
     }
   })
 }


### PR DESCRIPTION
Отловил пару ошибок в превью цвета внутри блоков кода.

Первая ошибка:

![image](https://user-images.githubusercontent.com/106589280/195877792-6bea33f7-eb28-45d8-b719-18a58cebe029.png)

Код выставляет для цвета превью «transparent» собственно `transparent`, и он становится либо белым, либо чёрным в зависимости от темы. Добавил исключение, чтобы `transparent` оставался без превью:

Стало:

![image](https://user-images.githubusercontent.com/106589280/195878096-99e575fc-fe4f-452d-beac-ce3a4773f714.png)

Вторая ошибка:

Я добавил отступ для превью, если перед этим есть скобка (чтобы не было слипания). Но вот в таких случаях скобка есть, но отступ не нужен:

![image](https://user-images.githubusercontent.com/106589280/195878356-d65d9daa-26e8-4629-a947-9668b32dfc51.png)

Видно, что `red` сдвинулся. Поэтому добавил отступ для скобки, а не для превью.

Стало в уровень:

![image](https://user-images.githubusercontent.com/106589280/195878566-0ee37657-92bb-4151-92c2-5ae6abaea2b2.png)

Предлагаю поправить, чтобы было не только красиво, но и везде всё хорошо 🙃