### PR TITLE
Правит стили для кнопок-фильтров

### DIFF
--- a/src/styles/blocks/tag-filter.css
+++ b/src/styles/blocks/tag-filter.css
@@ -30,7 +30,10 @@
   line-height: 1;
   text-align: center;
   border-radius: 2em;
-  transition: background-color 125ms;
+  transition: all 125ms;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
 }
 
 .tag-filter__text::before {


### PR DESCRIPTION
PR призван решить две проблемы:

1. В кнопках-фильтрах выделяется текст, и это некрасиво и неудобно. Предлагаю убрать эффект!

![image](https://user-images.githubusercontent.com/106589280/196730302-54c8ec3b-6a96-4906-bcef-7bab746e2a48.png)

2. На дефолтной кнопке `все` нет транзишена на `color`, из-за чего переход резкий. Предлагаю добавить.

Было: 

https://user-images.githubusercontent.com/106589280/196731635-606a5cd8-2f10-4a6c-8f0d-2ea68e03dee2.mp4

Стало:


https://user-images.githubusercontent.com/106589280/196732632-55c889e1-8fed-4133-809b-931764de7058.mp4



