### PR TITLE
Меняет эмоджи напротив «Участники»

### DIFF
--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -19,7 +19,7 @@
         </p>
         <div class="intro__footer">
           <div class="intro__link">
-            🔥
+            🙌
             <a class="link" href="/people">Участники</a>
           </div>
           <div class="intro__link">


### PR DESCRIPTION
Предлагаю внести мини-правку по следующей логике.

Участники — это люди, следовательно напротив ссылки должно быть что-то, что олицетворяет либо людей, либо помощь, либо взаимодействие людей и всё в таком духе. А сейчас там огонь, меня это немного смущало всегда 😀

Может поставить вот такой эмоджи: 🙌. Очеловеченный и символизирующий связь. Например.

![image](https://user-images.githubusercontent.com/106589280/196926187-3c8c9f20-ef61-4a14-9209-15fa0114c2d4.png)
