### PR TITLE
Добавляет поддержку анимации лого в расширенном поиске

### DIFF
--- a/src/scripts/modules/logo.js
+++ b/src/scripts/modules/logo.js
@@ -38,8 +38,17 @@ class Logo {
   }
 
   endAnimation() {
-    const firstResultColor = document?.querySelector('.suggestion-list__item')?.getAttribute('style')
-    const logoImage = document.querySelectorAll('.logo__image')[1]
+    const isSearchPage = window.location.pathname.indexOf('/search/') > -1
+    let logoImage
+    let firstResultColor
+
+    if (isSearchPage) {
+      logoImage = document.querySelector('.logo__image')
+      firstResultColor = document?.querySelector('.search-hit')?.getAttribute('style')
+    } else {
+      logoImage = document.querySelectorAll('.logo__image')[1]
+      firstResultColor = document?.querySelector('.suggestion-list__item')?.getAttribute('style')
+    }
 
     if (firstResultColor) {
       logoImage.setAttribute('style', `${firstResultColor}`)


### PR DESCRIPTION
Кажется, я не заметил, что в расширенном поиске совсем другие классы поисковых результатов и количество лого 😥, из-за чего анимация выключается только для главной. 

Внёс поддержку страницы расширенного поиска ✏