### PR TITLE
Фиксит копирование ссылок

### DIFF
--- a/src/scripts/modules/toc.js
+++ b/src/scripts/modules/toc.js
@@ -81,8 +81,14 @@ function init() {
     )
   }
 
-  function saveHistory(hash) {
-    history.pushState(null, null, hash)
+  function saveLink(link) {
+    try {
+      navigator.clipboard
+        .writeText(link)
+        .catch((error) => console.log(`Ошибка при копировании ссылки: ${error.message}`))
+    } catch (error) {
+      console.log(`Возможно, соединение незащищенное. Ошибка: ${error.message}`) // доступ к clipboard работает только под https
+    }
   }
 
   function scrollToTitle(hash) {
@@ -158,8 +164,20 @@ function init() {
 
     event.preventDefault()
     scrollToTitle(link.hash)
-    saveHistory(link.hash)
   })
+
+  document.querySelectorAll(HEADING_LINK_SELECTOR)?.forEach((item) =>
+    item.addEventListener('click', (event) => {
+      const link = event.target.closest(HEADING_LINK_SELECTOR)
+
+      if (!link) {
+        return
+      }
+
+      event.preventDefault()
+      saveLink(link.href)
+    })
+  )
 }
 
 init()

--- a/src/styles/blocks/article-heading.css
+++ b/src/styles/blocks/article-heading.css
@@ -32,6 +32,10 @@
   height: auto;
 }
 
+.article-heading__icon:active {
+  width: 0.6em;
+}
+
 .article-heading__code {
   font-size: 1.2em;
   font-family: var(--font-family);


### PR DESCRIPTION
Fix #1022

Поменял функцию saveHistory, потому что раньше она работала с историей браузера, а не с буфером обмена, поэтому ничего не копировалось. Теперь должно быть все ок :)

Ещё добавил небольшую фичу, чтобы значок копирования ссылки уменьшался при клике, поскольку сейчас не интуитивно понятно, скопировалось что-то или нет. 

P.S. clipboard работает только на https, тестил через [ngrok](https://ngrok.com/)

Предлагаю такой вариант 🙂