### PR TITLE
[На собеседовании] Меняет ссылку на инструкцию

### DIFF
--- a/src/includes/questions.njk
+++ b/src/includes/questions.njk
@@ -44,7 +44,7 @@
     </h2>
 
     <p class="questions__description">
-      Это партнёрская рубрика, мы выпускаем её совместно с сервисом онлайн-образования <a href="https://practicum.yandex.ru/programming-upskilling/?utm_source=pr&utm_medium=content&utm_campaign=pr_content_programming-upskilling_doka?utm_content=na-sobese" title="Каталог курсов по программированию от Яндекс Практикума">Яндекс Практикум</a>. Приносите вопрос, на который не знаете ответа, в <a href="https://github.com/doka-guide/content/issues?q=is%3Aopen+is%3Aissue+label%3Aсобеседование" title="Все задачи для контента Доки, отфильтрованные по лейблу «собеседование»">задачи</a>, мы разложим всё по полочкам и опубликуем. Если знаете ответ, присылайте <a href="https://github.com/doka-guide/content/blob/main/docs/contributing.md" title="Общая инструкция по написанию новых материалов для Доки">пулреквест на GitHub</a>.
+      Это партнёрская рубрика, мы выпускаем её совместно с сервисом онлайн-образования <a href="https://practicum.yandex.ru/programming-upskilling/?utm_source=pr&utm_medium=content&utm_campaign=pr_content_programming-upskilling_doka?utm_content=na-sobese" title="Каталог курсов по программированию от Яндекс Практикума">Яндекс Практикум</a>. Приносите вопрос, на который не знаете ответа, в <a href="https://github.com/doka-guide/content/issues?q=is%3Aopen+is%3Aissue+label%3Aсобеседование" title="Все задачи для контента Доки, отфильтрованные по лейблу «собеседование»">задачи</a>, мы разложим всё по полочкам и опубликуем. Если знаете ответ, присылайте <a href="https://github.com/doka-guide/content/blob/main/docs/interviews.md" title="Инструкция по созданию вопросов и ответов для рубрики">пулреквест на GitHub</a>.
     </p>
 
     <div class="questions__list">


### PR DESCRIPTION
Раньше в сопроводительном тексте стояла ссылка на общий туториал для контрибьюторов. Теперь ссылка ведёт на инструкцию конкретно для этого раздела.