### PR TITLE
Чинит врезки в текст

### DIFF
--- a/src/styles/blocks/callout.css
+++ b/src/styles/blocks/callout.css
@@ -19,6 +19,7 @@
 .callout__content {
   --background-code-color: hsl(var(--color-base-background));
   display: flex;
+  flex-direction: column;
   flex: 1 1 320px;
   gap: 5px;
 }


### PR DESCRIPTION
Fix #1029

Кажется, flex выровнял элементы в строку. Исправил на `column`, вроде ничего?)

![image](https://user-images.githubusercontent.com/106589280/199274389-c23eceb6-f8e6-4b15-948a-d5cb98f83c13.png)
