### PR TITLE
Чинит шаблон врезки вопроса для интервью

### DIFF
--- a/src/includes/questions.njk
+++ b/src/includes/questions.njk
@@ -52,8 +52,9 @@
       {% for question in questions %}
         <div class="question__request">
           <aside class="callout">
+            <div class="callout__icon">❓</div>
             <div class="callout__content">
-              <span aria-hidden="true">❓</span> {{ question.templateContent | safe }}
+              {{ question.templateContent | safe }}
             </div>
           </aside>
         </div>


### PR DESCRIPTION
В запале долгожданного релиза чуть неправильно был создан шаблон для вопросов для рубрики «На собеседовании». Вытащила иконку из контента, поставила отдельно. Теперь она красиво стоит сбоку от текста, а не над ним.

Было 

<img width="1128" alt="CleanShot 2022-11-28 at 16 01 20@2x" src="https://user-images.githubusercontent.com/13676514/204272867-991361df-b149-4576-8589-e5a2f9f71b44.png">


Стало 

<img width="1109" alt="CleanShot 2022-11-28 at 16 01 35@2x" src="https://user-images.githubusercontent.com/13676514/204272898-bb63b99c-96fb-4b4f-959a-e54d45262a3f.png">
