### PR TITLE
Правит размер шрифта для <code> в карточках статей на главной #1037

### DIFF
--- a/src/styles/blocks/featured-article.css
+++ b/src/styles/blocks/featured-article.css
@@ -47,14 +47,12 @@
 }
 
 .featured-article__title {
-  --font-size: var(--font-size-xl);
-  --line-height: var(--font-line-height-xl);
   margin: 0;
   padding: var(--gutter);
   font-family: var(--font-family);
   letter-spacing: var(--letter-spacing);
-  font-size: var(--font-size);
-  line-height: var(--line-height);
+  font-size: var(--font-size-xl);
+  line-height: var(--font-line-height-xl);
   font-weight: normal;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -63,8 +61,8 @@
 .featured-article__code {
   font-family: var(--font-family);
   letter-spacing: var(--letter-spacing);
-  font-size: var(--font-size, var(--font-size-m));
-  line-height: var(--line-height, var(--font-line-height-m));
+  font-size: var(--font-size-xl);
+  line-height: var(--font-line-height-xl);
 }
 
 .featured-article__link {


### PR DESCRIPTION
Было
<img width="469" alt="Снимок экрана 2022-11-29 в 04 04 09" src="https://user-images.githubusercontent.com/98118128/204399810-b43a9f9b-5d80-429e-abb3-bdd4a6886921.png">

Стало
<img width="474" alt="Снимок экрана 2022-11-29 в 04 03 51" src="https://user-images.githubusercontent.com/98118128/204399845-67b2005d-8f04-4f47-ade3-2084716b56d5.png">

