### PR TITLE
Правит размер шрифта для <code> в параграфах с кратким содержанием статьи #1037

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,7 +1,7 @@
 name: PR Preview
 
 on:
-  pull_request
+  pull_request_target
 
 jobs:
   preview:

--- a/src/styles/blocks/featured-article.css
+++ b/src/styles/blocks/featured-article.css
@@ -89,6 +89,10 @@
   padding: var(--gutter);
 }
 
+.featured-article__description .featured-article__code {
+  font-size: var(--font-size-m);
+}
+
 @media (min-width: 768px) {
   .featured-article {
     min-height: 402px;

--- a/src/transforms/headings-anchor-transform.js
+++ b/src/transforms/headings-anchor-transform.js
@@ -10,7 +10,7 @@ function createLinkMarkup(id, headingText) {
         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
         <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
       </svg>
-      <span class="visually-hidden">Секция статьи "${headingText}"</span>
+      <span class="visually-hidden">Секция статьи "${headingText.replace(/(<|>)/g, '')}"</span>
     </a>
   `
 }


### PR DESCRIPTION
Было:
![image](https://user-images.githubusercontent.com/98118128/206692333-4e7a3551-18f4-4dff-af79-ad574499ba1c.png)

Стало:
<img width="1069" alt="Снимок экрана 2022-12-09 в 17 23 03" src="https://user-images.githubusercontent.com/98118128/206692272-630d4bb1-6377-4567-a552-f7c1b0b089b5.png">
