### PR TITLE
Чинит ReferenceError в шапке

### DIFF
--- a/src/includes/blocks/featured-article.njk
+++ b/src/includes/blocks/featured-article.njk
@@ -8,8 +8,7 @@
           class="featured-article__image"
           src="{{ article.imageLink }}"
           {% if isLazyLoading %}loading="lazy"{% endif %}
-          alt="Иллюстрация к статье “{{ article.title }}”"
-          aria-hidden="true"
+          alt=""
         >
       </picture>
     {% endif %}

--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -208,7 +208,19 @@ async function getActionsInRepo({ authors, authorIDs, repo }) {
     return []
   }
 
-  const [authorActions] = await Promise.all([getData(buildQueryForAuthorActions({ authors, authorIDs, repo }))])
+  let authorActions = {}
+
+  const chunkSize = 10
+  for (let i = 0; i < authors.length; i += chunkSize) {
+    const chunk = authors.slice(i, i + chunkSize)
+    const [chunkAuthorActions] = await Promise.all([
+      getData(buildQueryForAuthorActions({ authors: chunk, authorIDs, repo })),
+    ])
+    authorActions = {
+      ...authorActions,
+      ...chunkAuthorActions,
+    }
+  }
 
   return authors.reduce((usersData, author) => {
     const escapedName = escape(author)

--- a/src/scripts/libs/__tests__/toc-text-crop-test.js
+++ b/src/scripts/libs/__tests__/toc-text-crop-test.js
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
-const { MAX_LENGTH, clipContent } = require('../../modules/toc-text-crop.js')
+// const { MAX_LENGTH, clipContent } = require('../../modules/toc-text-crop.js')
+import { MAX_LENGTH, clipContent } from '../../modules/toc-text-crop.js'
+
 const headersTemplate = [
   'Фильдеперсовый Константинопольский шпалоукладчик звукоизвлекает сложносочинённые турбопропизоляционные ноктюрны',
   'Это самое обычное предложение, полная длина которого составляет завораживающее значение 90',

--- a/src/scripts/libs/__tests__/toc-text-crop-test.js
+++ b/src/scripts/libs/__tests__/toc-text-crop-test.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 
-// const { MAX_LENGTH, clipContent } = require('../../modules/toc-text-crop.js')
 import { MAX_LENGTH, clipContent } from '../../modules/toc-text-crop.js'
 
 const headersTemplate = [

--- a/src/scripts/modules/toc-text-crop.js
+++ b/src/scripts/modules/toc-text-crop.js
@@ -20,3 +20,5 @@ const clipContent = (linksArray, maxLength) => {
 }
 
 clipContent(tocLinks, MAX_LENGTH)
+
+export default { clipContent, MAX_LENGTH }

--- a/src/scripts/modules/toc-text-crop.js
+++ b/src/scripts/modules/toc-text-crop.js
@@ -20,8 +20,3 @@ const clipContent = (linksArray, maxLength) => {
 }
 
 clipContent(tocLinks, MAX_LENGTH)
-
-module.exports = {
-  MAX_LENGTH,
-  clipContent,
-}

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -32,7 +32,7 @@
       </div>
       <div class="intro__pitch intro__pitch--partner">
         <a target="_blank" rel="nofollow" href="https://practicum.yandex.ru/programming-upskilling/?utm_source=pr&utm_medium=content&utm_campaign=pr_content_programming-upskilling_doka">
-          <img class="intro__logo intro__logo--invertible" src="/images/partners/practicum.svg">
+          <img class="intro__logo intro__logo--invertible" src="/images/partners/practicum.svg" alt="Практикум">
         </a>
         <p class="intro__description">
           Работу редакции Доки поддерживает <a class="link" target="_blank" rel="nofollow" href="https://practicum.yandex.ru/programming-upskilling/?utm_source=pr&utm_medium=content&utm_campaign=pr_content_programming-upskilling_doka">Яндекс Практикум</a> — сервис онлайн-образования. Вместе мы помогаем сообществу развиваться и становиться лучше. Дока развивает площадку для накопления опыта, а Практикум помогает разработчикам изучать новое и расти.

--- a/src/views/people.njk
+++ b/src/views/people.njk
@@ -29,6 +29,9 @@
   ) }}
 
   <main class="people-page__main">
+    <h1 class="visually-hidden">
+      {{ title }}
+    </h1>
     <form class="people-page__filter filter-panel" autocomplete="off">
       <fieldset class="filter-panel__inner">
         <legend class="visually-hidden">Фильтровать по:</legend>


### PR DESCRIPTION
В локальной Доке

1. Не сворачивается заголовок, ни по кнопке закрыть, ни по нажатию на ESC
2. Не работает поиск

Браузер сообщает:

> Uncaught ReferenceError: module is not defined at [toc-text-crop.js:24:1](https://github.com/doka-guide/platform/blob/main/src/scripts/modules/toc-text-crop.js#L24)

Браузер явно ругается на модуль, но тут обычный скрипт, который не встраивается, как модуль. Убирает, всё заработало, но лучше проверить.

Fix #1085