### PR TITLE
Корректирует адаптивную вёрстку на странице профиля участника

### DIFF
--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -208,7 +208,19 @@ async function getActionsInRepo({ authors, authorIDs, repo }) {
     return []
   }
 
-  const [authorActions] = await Promise.all([getData(buildQueryForAuthorActions({ authors, authorIDs, repo }))])
+  let authorActions = {}
+
+  const chunkSize = 10
+  for (let i = 0; i < authors.length; i += chunkSize) {
+    const chunk = authors.slice(i, i + chunkSize)
+    const [chunkAuthorActions] = await Promise.all([
+      getData(buildQueryForAuthorActions({ authors: chunk, authorIDs, repo })),
+    ])
+    authorActions = {
+      ...authorActions,
+      ...chunkAuthorActions,
+    }
+  }
 
   return authors.reduce((usersData, author) => {
     const escapedName = escape(author)

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -318,7 +318,7 @@
   }
 }
 
-@media all and (min-width: 430px) {
+@media all and (min-width: 431px) {
   .header__category.header__category--visible {
     display: flex;
   }

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -318,7 +318,7 @@
   }
 }
 
-@media all and (min-width: 431px) {
+@media all and (min-width: 430px) {
   .header__category.header__category--visible {
     display: flex;
   }

--- a/src/styles/blocks/person-badges.css
+++ b/src/styles/blocks/person-badges.css
@@ -4,13 +4,8 @@
   grid-area: badges;
   display: grid;
   grid-template-columns: repeat(var(--col-count), 1fr);
+  grid-template-rows: repeat(var(--row-count), 1fr);
   margin-bottom: 1em;
-}
-
-@media (min-width: 1024px) {
-  .person-badges {
-    grid-template-rows: repeat(var(--row-count), 1fr);
-  }
 }
 
 .person-badges__sign {

--- a/src/styles/blocks/person-badges.css
+++ b/src/styles/blocks/person-badges.css
@@ -8,12 +8,6 @@
   margin-bottom: 1em;
 }
 
-@media (min-width: 320px) {
-  .person-badges {
-    max-width: 250px;
-  }
-}
-
 @media (min-width: 1024px) {
   .person-badges {
     grid-template-rows: repeat(var(--row-count), 1fr);

--- a/src/styles/blocks/person-badges.css
+++ b/src/styles/blocks/person-badges.css
@@ -8,6 +8,18 @@
   margin-bottom: 1em;
 }
 
+@media (min-width: 320px) {
+  .person-badges {
+    max-width: 250px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .person-badges {
+    grid-template-rows: repeat(var(--row-count), 1fr);
+  }
+}
+
 .person-badges__sign {
   position: relative;
   --start-col: 1;

--- a/src/styles/blocks/person-page.css
+++ b/src/styles/blocks/person-page.css
@@ -103,7 +103,7 @@
   align-self: end;
 }
 
-@media (max-width: 686px) {
+@media (max-width: 450px) {
   .person-page {
     grid-template-columns: 100%;
   }

--- a/src/styles/blocks/person-page.css
+++ b/src/styles/blocks/person-page.css
@@ -90,7 +90,7 @@
   grid-area: articles;
   display: grid;
   gap: var(--offset);
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  grid-template-columns: minmax(min(100%, 320px), 1fr);
   max-width: 960px;
 }
 
@@ -118,6 +118,10 @@
 @media (min-width: 768px) {
   .person-page {
     --offset: 20px;
+  }
+
+  .person-page__articles {
+    grid-template-columns: repeat(2, minmax(min(100%, 320px), 1fr));
   }
 
   .person-page__main {
@@ -169,13 +173,6 @@
 @media (min-width: 1440px) {
   .person-page {
     --sidebar-size-end: 1fr;
-  }
-
-  .person-page__main {
-    grid-template-areas:
-      'avatar header   .'
-      'meta   articles .'
-      '.      footer   footer';
   }
 }
 

--- a/src/styles/blocks/person-page.css
+++ b/src/styles/blocks/person-page.css
@@ -103,15 +103,19 @@
   align-self: end;
 }
 
-@media (min-width: 320px) {
+@media (max-width: 686px) {
+  .person-page {
+    grid-template-columns: 100%;
+  }
+
   .person-page__main {
     grid-template-columns: 100%;
     grid-template-areas:
-      'avatar   . .'
-      'header   . .'
-      'articles . .'
-      'meta     . .'
-      'footer   . .';
+      'avatar'
+      'header'
+      'meta'
+      'articles'
+      'footer';
   }
 }
 

--- a/src/styles/blocks/person-page.css
+++ b/src/styles/blocks/person-page.css
@@ -103,19 +103,15 @@
   align-self: end;
 }
 
-@media (max-width: 450px) {
-  .person-page {
-    grid-template-columns: 100%;
-  }
-
+@media (min-width: 320px) {
   .person-page__main {
     grid-template-columns: 100%;
     grid-template-areas:
-      'avatar'
-      'header'
-      'meta'
-      'articles'
-      'footer';
+      'avatar   . .'
+      'header   . .'
+      'articles . .'
+      'meta     . .'
+      'footer   . .';
   }
 }
 


### PR DESCRIPTION
Приветствую! 🖖

1) Заметил, что на участнике [Ольга Алексашенко](https://doka.guide/people/tachisis/) появляется нижний скролл на разрешениях **768-976px** и **1024-1221px**.
____

2) Также, **на блоке с ачивками** у участника [Алёна Батицкая](https://doka.guide/people/solarrust/) (по крайней мере во время отладки) - ачивки решили наложиться друг на дружку. 
![image](https://user-images.githubusercontent.com/48220644/212562824-1362dd54-b138-4782-85f5-87722326e2d8.png)
____
3) Последний момент - это на разрешении **1440px+** происходит уменьшение ширины общего блока для имени, описания и колонок со списками, где участник является автором или редактором.

### <1440px

![image](https://user-images.githubusercontent.com/48220644/212563318-73cbf4b9-b8e2-48a1-ab6a-45dfa5d2e648.png)
 
### >1440px

![image](https://user-images.githubusercontent.com/48220644/212563374-ba0b569b-1994-4943-836d-b3aa28b67178.png)

Мне показалось это странным поведением, поэтому решил оставить одну ширину общего блока - **ДО 1440px**. 

Проблемы все исправлены 😉
