### PR TITLE
Исправляет раскрывающиеся меню с фильтрами по разделам (поиск, участники)

### DIFF
--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -208,7 +208,19 @@ async function getActionsInRepo({ authors, authorIDs, repo }) {
     return []
   }
 
-  const [authorActions] = await Promise.all([getData(buildQueryForAuthorActions({ authors, authorIDs, repo }))])
+  let authorActions = {}
+
+  const chunkSize = 10
+  for (let i = 0; i < authors.length; i += chunkSize) {
+    const chunk = authors.slice(i, i + chunkSize)
+    const [chunkAuthorActions] = await Promise.all([
+      getData(buildQueryForAuthorActions({ authors: chunk, authorIDs, repo })),
+    ])
+    authorActions = {
+      ...authorActions,
+      ...chunkAuthorActions,
+    }
+  }
 
   return authors.reduce((usersData, author) => {
     const escapedName = escape(author)

--- a/src/scripts/modules/filter-panel.js
+++ b/src/scripts/modules/filter-panel.js
@@ -1,6 +1,9 @@
 function init() {
   const filterPanel = document.querySelector('.filter-panel')
   const button = document.querySelector('.filter-panel__button')
+  const buttonName = document.querySelector('.float-button__name')
+  const buttonNameText = buttonName.innerHTML
+  let expanded = false
 
   if (!filterPanel && !button) {
     return
@@ -9,6 +12,16 @@ function init() {
   button.addEventListener('click', () => {
     filterPanel.classList.toggle('filter-panel--open')
   })
+
+  if (expanded) {
+    button.setAttribute('aria-expanded', 'false')
+    buttonName.innerHTML = buttonNameText
+    expanded = false
+  } else {
+    button.setAttribute('aria-expanded', 'true')
+    buttonName.innerHTML = 'Скрыть фильтр'
+    expanded = true
+  }
 }
 
 init()

--- a/src/scripts/modules/search-page-filter.js
+++ b/src/scripts/modules/search-page-filter.js
@@ -1,6 +1,9 @@
 function init() {
   const filterPanel = document.querySelector('.search-page__aside')
   const button = document.querySelector('.search-page__aside-button')
+  const buttonName = document.querySelector('.search-page__aside-button-name')
+  const buttonNameText = buttonName.innerHTML
+  let expanded = false
 
   if (!filterPanel && !button) {
     return
@@ -9,6 +12,16 @@ function init() {
   button.addEventListener('click', () => {
     filterPanel.classList.toggle('search-page__aside--open')
   })
+
+  if (expanded) {
+    button.setAttribute('aria-expanded', 'false')
+    buttonName.innerHTML = buttonNameText
+    expanded = false
+  } else {
+    button.setAttribute('aria-expanded', 'true')
+    buttonName.innerHTML = 'Скрыть фильтр'
+    expanded = true
+  }
 }
 
 init()

--- a/src/styles/blocks/people-page.css
+++ b/src/styles/blocks/people-page.css
@@ -8,7 +8,7 @@
 }
 
 .people-page__filter {
-  z-index: 1;
+  z-index: 2;
 }
 
 .people-page__list {

--- a/src/styles/blocks/search-page.css
+++ b/src/styles/blocks/search-page.css
@@ -158,6 +158,7 @@
     display: flex;
     flex-direction: column;
     border-top: 0;
+    z-index: 2;
   }
 
   .search-page__aside::before {

--- a/src/views/people.njk
+++ b/src/views/people.njk
@@ -54,8 +54,8 @@
         </div>
       </fieldset>
 
-      <button class="filter-panel__button float-button" type="button">
-        <span class="visually-hidden">Показать/скрыть фильтр</span>
+      <button class="filter-panel__button float-button" type="button" aria-expanded="false">
+        <span class="float-button__name visually-hidden">Показать фильтр</span>
         <div class="float-button__icons" aria-hidden="true">
           <svg class="float-button__icon float-button__icon--close" width="48" height="48" fill="currentColor" viewBox="0 0 48 48">
             <path d="M31.27 32.88l-7.3-7.3-7.24 7.24c-.43.43-.8.58-1.15.58a.94.94 0 01-.71-.26.94.94 0 01-.27-.72c0-.34.15-.72.58-1.15l7.24-7.24-7.24-7.23c-.43-.43-.58-.81-.58-1.16 0-.32.1-.54.27-.7a.94.94 0 01.7-.28c.35 0 .73.16 1.16.59l7.24 7.23 7.3-7.3c.44-.44.8-.58 1.09-.58.15 0 .36.07.62.37.28.3.36.55.36.73 0 .3-.14.65-.52 1.03l-7.3 7.3 7.3 7.3c.44.44.58.8.58 1.1 0 .15-.07.36-.37.62-.3.27-.55.35-.73.35-.3 0-.65-.13-1.03-.52z"></path>

--- a/src/views/search.njk
+++ b/src/views/search.njk
@@ -42,8 +42,8 @@ title: 'Поиск'
       {% include "blocks/search-tags.njk" %}
     </div>
 
-    <button class="search-page__aside-button" type="button">
-      <span class="visually-hidden">Показать/скрыть фильтр</span>
+    <button class="search-page__aside-button" type="button" aria-expanded="false">
+      <span class="search-page__aside-button-name visually-hidden">Показать фильтр</span>
       <div class="search-page__aside-icon-wrapper" aria-hidden="true">
         <svg class="search-page__aside-icon search-page__aside-icon--close" width="48" height="48" fill="currentColor" viewBox="0 0 48 48">
           <path d="M31.27 32.88l-7.3-7.3-7.24 7.24c-.43.43-.8.58-1.15.58a.94.94 0 01-.71-.26.94.94 0 01-.27-.72c0-.34.15-.72.58-1.15l7.24-7.24-7.24-7.23c-.43-.43-.58-.81-.58-1.16 0-.32.1-.54.27-.7a.94.94 0 01.7-.28c.35 0 .73.16 1.16.59l7.24 7.23 7.3-7.3c.44-.44.8-.58 1.09-.58.15 0 .36.07.62.37.28.3.36.55.36.73 0 .3-.14.65-.52 1.03l-7.3 7.3 7.3 7.3c.44.44.58.8.58 1.1 0 .15-.07.36-.37.62-.3.27-.55.35-.73.35-.3 0-.65-.13-1.03-.52z" />


### PR DESCRIPTION
Сейчас на мобильниках выпадающие меню с фильтрами по разделам на страницах поиска и участников располагаются под меню из-за более низкого `z-index` у них. Особенно хорошо это заметно, когда на странице немного контента.

![Меню с фильтрами визуально расположена под меню.](https://user-images.githubusercontent.com/17615202/212674793-65c035b1-981b-4b8f-a92c-818822ba05ff.jpg)

Так что я задала более высокое значение для дропдаунов с фильтрами.

Вторая доработка — то, как изменяется название кнопки при взаимодействии с ней. Сейчас кнопка называется всегда «Показать/скрыть фильтр». В этом ПР я изменяю её название динамически в зависимости от того, открыт дропдаун или нет.

Третья доработка — `aria-expanded` у кнопки. Так как она что-то показывает и скрывает, хорошо это свойство обозначить и на уровне кода. `aria-controls` решила не добавлять, так как у атрибута так себе поддержка. Можно добавить, если она расширится.