### PR TITLE
Поправляет порядок фокуса при взаимодействии с кнопкой «Показать ещё» (главная, 404)

### DIFF
--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -208,7 +208,19 @@ async function getActionsInRepo({ authors, authorIDs, repo }) {
     return []
   }
 
-  const [authorActions] = await Promise.all([getData(buildQueryForAuthorActions({ authors, authorIDs, repo }))])
+  let authorActions = {}
+
+  const chunkSize = 10
+  for (let i = 0; i < authors.length; i += chunkSize) {
+    const chunk = authors.slice(i, i + chunkSize)
+    const [chunkAuthorActions] = await Promise.all([
+      getData(buildQueryForAuthorActions({ authors: chunk, authorIDs, repo })),
+    ])
+    authorActions = {
+      ...authorActions,
+      ...chunkAuthorActions,
+    }
+  }
 
   return authors.reduce((usersData, author) => {
     const escapedName = escape(author)

--- a/src/scripts/modules/articles-gallery.js
+++ b/src/scripts/modules/articles-gallery.js
@@ -19,13 +19,18 @@ function init() {
   }
 
   const activeClass = 'featured-articles-list__item--active'
+  const linkClass = '.featured-article__link'
 
   const pageSize = parseInt(getComputedStyle(list).getPropertyValue('--page-size'), 10) || 1
   let lastItemIndex = pageSize
 
   function loadItems() {
-    items.slice(lastItemIndex, lastItemIndex + pageSize).forEach((item) => {
+    items.slice(lastItemIndex, lastItemIndex + pageSize).forEach((item, index) => {
       item.classList.add(activeClass)
+
+      if (index === 0) {
+        item.querySelector(linkClass).focus()
+      }
     })
 
     lastItemIndex += pageSize


### PR DESCRIPTION
Сейчас в блоках с фичеринг-статьями на главной и 404 страницах клавиатурный фокус после нажатия на кнопку «Показать ещё» оказывается на первой ссылке после пропавшей кнопки — «HTML». Получается, что пользователям клавиатуры для того, чтобы посмотреть какие появились ещё статьи, надо протабывать вверх.

Я слегка изменила скрипт так, чтобы фокус после клика на кнопке устанавливался на первой ссылке из группы появившихся элементов на странице.

Правки в рамках #1068.