### PR TITLE
Добавляет скрытый лейбл для поля поиска

### DIFF
--- a/src/includes/blocks/search.njk
+++ b/src/includes/blocks/search.njk
@@ -1,6 +1,7 @@
 <form class="header__search search font-theme font-theme--code" method="get" name="search-form" action="/search/" id="search-form">
   <div class="search__control">
-    <input class="search__input" type="text" name="query" placeholder="Поиск" autocomplete="off">
+    <label class="visually-hidden" for="search-field">Поиск</label>  
+    <input class="search__input" type="text" name="query" id="search-field" placeholder="Поиск" autocomplete="off">
 
     <kbd class="hotkey search__key search__key--activate">/</kbd>
     <kbd class="hotkey search__key search__key--enter">↲</kbd>

--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -208,7 +208,19 @@ async function getActionsInRepo({ authors, authorIDs, repo }) {
     return []
   }
 
-  const [authorActions] = await Promise.all([getData(buildQueryForAuthorActions({ authors, authorIDs, repo }))])
+  let authorActions = {}
+
+  const chunkSize = 10
+  for (let i = 0; i < authors.length; i += chunkSize) {
+    const chunk = authors.slice(i, i + chunkSize)
+    const [chunkAuthorActions] = await Promise.all([
+      getData(buildQueryForAuthorActions({ authors: chunk, authorIDs, repo })),
+    ])
+    authorActions = {
+      ...authorActions,
+      ...chunkAuthorActions,
+    }
+  }
 
   return authors.reduce((usersData, author) => {
     const escapedName = escape(author)


### PR DESCRIPTION
У поля поиска сейчас источник имени — `placeholder`. С точки зрения WCAG это допустимо, но на деле это не очень хорошая практика. Для поля поиска допустимо добавлять визуально скрытое имя с помощью HTML или ARIA. Так что я просто добавила скрытый `<label>`.

ПР решает проблему из #1058.