### PR TITLE
Улучшает разметку переключателя тем

### DIFF
--- a/src/includes/blocks/footer.njk
+++ b/src/includes/blocks/footer.njk
@@ -1,9 +1,10 @@
 {% macro footer(class, tag = 'footer') %}
   <footer class="footer {{ class if class }}">
-    <div class="footer__theme-toggle">
-      <span class="footer__theme-toggle-label">Тема:</span>
+    <fieldset class="footer__theme-toggle">
+      <legend class="visually-hidden">Тема:</legend>
+      <span class="footer__theme-toggle-label" aria-hidden="true">Тема:</span>
       {% include "blocks/theme-toggle.njk" %}
-    </div>
+    </fieldset>
     <ul class="footer__list footer-list font-theme font-theme--code base-list">
       <li class="footer-list__item">
         <a class="footer-list__link link" href="{{ constants.dokaOrgLink }}">GitHub</a>

--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -208,7 +208,19 @@ async function getActionsInRepo({ authors, authorIDs, repo }) {
     return []
   }
 
-  const [authorActions] = await Promise.all([getData(buildQueryForAuthorActions({ authors, authorIDs, repo }))])
+  let authorActions = {}
+
+  const chunkSize = 10
+  for (let i = 0; i < authors.length; i += chunkSize) {
+    const chunk = authors.slice(i, i + chunkSize)
+    const [chunkAuthorActions] = await Promise.all([
+      getData(buildQueryForAuthorActions({ authors: chunk, authorIDs, repo })),
+    ])
+    authorActions = {
+      ...authorActions,
+      ...chunkAuthorActions,
+    }
+  }
 
   return authors.reduce((usersData, author) => {
     const escapedName = escape(author)

--- a/src/styles/blocks/footer.css
+++ b/src/styles/blocks/footer.css
@@ -8,11 +8,14 @@
 }
 
 .footer__theme-toggle {
+  padding: 0;
+  margin: 0;
   display: flex;
   align-items: baseline;
   gap: 0.5em;
   font-size: var(--font-size-s);
   line-height: var(--font-line-height-s);
+  border: 0;
 }
 
 .footer__list {


### PR DESCRIPTION
ПР в рамках #1054.

Заменила `<div>` и `<span>` на `<fieldset>` и `<legend>` соответственно. Благодаря этому с точки зрения скринридеров это теперь группа чекбоксов с общим названием «Тема». И использовала этот хак с визуально скрытым именем и `<span>`, который скрыт от скринридеров. Он уже используется для других похожих элементов.

Как грустно, что этот баг с позиционированием `<legend>` не пофиксили всё ещё.