### PR TITLE
Улучшает разметку фильтров по разделам (поиск)

### DIFF
--- a/src/includes/blocks/search-category.njk
+++ b/src/includes/blocks/search-category.njk
@@ -1,6 +1,6 @@
 <fieldset class="search-category">
-  <legend class="visually-hidden" aria-hidden="true">Фильтровать по:</legend>
-  <div class="search-category__legend">Фильтровать по:</div>
+  <legend class="visually-hidden">Фильтровать по:</legend>
+  <div class="search-category__legend" aria-hidden="true">Фильтровать по:</div>
 
   {% for category in collections.articleIndexes %}
     <label class="search-category__item tag-filter" style="--accent-color: var(--color-{{ category.fileSlug }})">


### PR DESCRIPTION
На странице поиска сейчас у <fieldset> с фильтрами нет лейбла, который был бы доступен для скринридеров.

```html
<fieldset class="search-category">
    <legend class="visually-hidden" aria-hidden="true">Фильтровать по:</legend>
    <div class="search-category__legend">Фильтровать по:</div>
    …
</fieldset>
```

Я просто убрала из тега `<label>` атрибут `aria-hidden="true"` и, наоборот, добавила его к `<div>`, который визуально отображается на странице.

ПР закрывает #1055.