### PR TITLE
Разбирается с `alt` на странице всех участников

### DIFF
--- a/src/includes/blocks/person-avatar.njk
+++ b/src/includes/blocks/person-avatar.njk
@@ -10,7 +10,7 @@
     {% if inlineStyles %}style="{{ inlineStyles }}"{% endif %}
   >
     {% if photoURL %}
-      <img class="person-avatar__item person-avatar__image person__avatar" src="{{ photoURL }}" alt="Изображение автора '{{ name }}'">
+      <img class="person-avatar__item person-avatar__image person__avatar" src="{{ photoURL }}" alt="">
     {% else %}
       <div class="person-avatar__item person-avatar__placeholder font-theme font-theme--code" aria-hidden="true">ᴥ</div>
     {% endif %}


### PR DESCRIPTION
Кажется, что изображения на странице со всеми участниками декоративные. Даже если мы хотим оставлять описание картинок на этой странице, то сейчас оно некорректное. В нём есть слово «изображение» и оно никак не описывает картинку, к сожалению.

Если решим дать авторам возможность описывать свои аватарки в их профилях, то можно будет использовать это же описание на странице со всеми людьми.

ПР закрывает #1079.