### PR TITLE
Устраняет горизонтальный скролл на странице поиска

### DIFF
--- a/src/styles/blocks/search-hit.css
+++ b/src/styles/blocks/search-hit.css
@@ -60,7 +60,9 @@
   content: '✎';
 }
 
-.search-hit__summary {}
+.search-hit__summary {
+  overflow-wrap: anywhere;
+}
 
 .search-hit__marked {
   background-color: hsl(44deg 100% 59%);


### PR DESCRIPTION
Решение по теме #1056

Проблема возникает, поскольку по поиску ключа `DOM`  среди выдачи в строке `document.addEventListener('DOMContentLoaded',` браузер не находит пробелов для разбивки предложения, из-за чего возникает переполнение. Иных правил не задано. В тоже время внутри заголовка `search-hit__title` работает правило `word-break: break-word`.

Предлагаю добавить для контента выдачи правило на случай переполнения в лице `overflow-wrap: anywhere`.