### PR TITLE
Улучшает сообщение о скопированном коде

### DIFF
--- a/src/scripts/modules/copy-code-snippet.js
+++ b/src/scripts/modules/copy-code-snippet.js
@@ -33,11 +33,18 @@ function init() {
     }
 
     copyButton.disabled = true
+    let isTabPressed
 
     navigator.clipboard
       .writeText(contentElement.textContent)
       .then(() => {
         copyButton.dataset.state = STATES.SUCCESS
+
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Tab') {
+            isTabPressed = true
+          }
+        })
       })
       .catch(() => {
         copyButton.dataset.state = STATES.ERROR
@@ -46,6 +53,10 @@ function init() {
         setTimeout(() => {
           copyButton.dataset.state = STATES.IDLE
           copyButton.disabled = false
+
+          if (!isTabPressed) {
+            copyButton.focus()
+          }
         }, MESSAGE_TIMEOUT)
       })
   })

--- a/src/transforms/article-code-blocks-transform.js
+++ b/src/transforms/article-code-blocks-transform.js
@@ -53,9 +53,9 @@ module.exports = function (window) {
           <code class="block-code__original">${originalSplittedContent}</code>
           <code class="block-code__highlight">${highlightedContent}</code>
         </span>
-        <span class="block-code__tools">
+        <span class="block-code__tools" aria-live="polite">
           <button class="block-code__copy-button copy-button" type="button" data-state="idle">
-            <svg class="copy-button__icon" width="14" height="17" viewBox="0 0 14 17" fill="none" stroke="currentColor">
+            <svg class="copy-button__icon" width="14" height="17" viewBox="0 0 14 17" fill="none" stroke="currentColor" aria-hidden="true">
               <rect width="8.75" height="11.35" x="4.75" y="4.43" rx="1.5"/>
               <path d="M8.8 2.3c0-.72-.58-1.3-1.3-1.3H3a2 2 0 0 0-2 2v8.07c0 .9.73 1.63 1.63 1.63"/>
             </svg>


### PR DESCRIPTION
Исправила две вещи в рамках ишью #1072: теперь скринридер объявит о новом имени кнопки при удачном/неудачном копировании кода и при окончании таймаута, а ещё фокус вернётся на кнопку после того, как она снова станет активной без атрибута `disabled` (если не перешли к другому элементу).

Без этих изменений в скрипте фокус сбрасывается с кнопки после того, как она какое-то время была неактивна. Если не перешли к следующему элементу, а остались на кнопке, фокус пропадает и из-за этого не особо понятно, где окажешься после таба.