### PR TITLE
Исправляет поведение меню на главной

### DIFF
--- a/src/includes/blocks/header.njk
+++ b/src/includes/blocks/header.njk
@@ -72,18 +72,20 @@
       {% include "blocks/search.njk" %}
       {% include "blocks/nav-list.njk" %}
 
-      <div class="header__toggle">
-        <button class="menu-toggle" type="button">
-          <span class="visually-hidden">Закрыть меню</span>
-          <span class="menu-toggle__inner menu-toggle__inner--close">
-            <kbd class="hotkey font-theme font-theme--code">esc</kbd>
-            <svg class="menu-toggle__icon menu-toggle__icon--close" width="45" height="45" viewBox="0 0 45 45">
-              <circle cx="22.5" cy="22.5" r="22.5" fill="var(--color-text)" />
-              <path fill="var(--color-background)" d="M30.3 32.1c-.5 0-1-.2-1.4-.6l-6.5-6.6-6.5 6.5c-.5.5-1 .7-1.5.7-.4 0-.8-.1-1-.4-.3-.3-.5-.6-.5-1 0-.6.3-1.1.7-1.6l6.5-6.5-6.5-6.4c-.4-.5-.7-1-.7-1.5s.2-.8.4-1.1c.3-.3.7-.4 1.1-.4.5 0 1 .2 1.5.7l6.5 6.5 6.5-6.6c.5-.5 1-.7 1.5-.7.3 0 .7.2 1 .5.3.4.5.8.5 1.1 0 .5-.2 1-.7 1.4l-6.5 6.5 6.5 6.6c.5.5.7 1 .7 1.4 0 .4-.1.7-.5 1-.4.4-.7.5-1 .5z"/>
-            </svg>
-          </span>
-        </button>
-      </div>
+      {% if not isMainPage %}
+        <div class="header__toggle">
+          <button class="menu-toggle" type="button">
+            <span class="visually-hidden">Закрыть меню</span>
+            <span class="menu-toggle__inner menu-toggle__inner--close">
+              <kbd class="hotkey font-theme font-theme--code">esc</kbd>
+              <svg class="menu-toggle__icon menu-toggle__icon--close" width="45" height="45" viewBox="0 0 45 45">
+                <circle cx="22.5" cy="22.5" r="22.5" fill="var(--color-text)" />
+                <path fill="var(--color-background)" d="M30.3 32.1c-.5 0-1-.2-1.4-.6l-6.5-6.6-6.5 6.5c-.5.5-1 .7-1.5.7-.4 0-.8-.1-1-.4-.3-.3-.5-.6-.5-1 0-.6.3-1.1.7-1.6l6.5-6.5-6.5-6.4c-.4-.5-.7-1-.7-1.5s.2-.8.4-1.1c.3-.3.7-.4 1.1-.4.5 0 1 .2 1.5.7l6.5 6.5 6.5-6.6c.5-.5 1-.7 1.5-.7.3 0 .7.2 1 .5.3.4.5.8.5 1.1 0 .5-.2 1-.7 1.4l-6.5 6.5 6.5 6.6c.5.5.7 1 .7 1.4 0 .4-.1.7-.5 1-.4.4-.7.5-1 .5z"/>
+              </svg>
+            </span>
+          </button>
+        </div>
+      {% endif %}
     </div>
   </header>
 {% endmacro %}

--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -89,9 +89,9 @@ class Header extends BaseComponent {
     return this.refs.rootElement.classList.contains('header--fixed')
   }
 
-  // get isMainPage() {
-  //   return this.refs.rootElement.classList.contains('header--main')
-  // }
+  get isMainPage() {
+    return this.refs.rootElement.classList.contains('header--main')
+  }
 
   get isClosableHeader() {
     const header = this.refs.rootElement
@@ -247,7 +247,7 @@ class Header extends BaseComponent {
         this.hideHeader()
       }
     } else {
-      if (!this.isFixed) {
+      if (!this.isFixed && !this.isMainPage) {
         this.showHeader()
       }
     }

--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -89,9 +89,9 @@ class Header extends BaseComponent {
     return this.refs.rootElement.classList.contains('header--fixed')
   }
 
-  get isMainPage() {
-    return this.refs.rootElement.classList.contains('header--main')
-  }
+  // get isMainPage() {
+  //   return this.refs.rootElement.classList.contains('header--main')
+  // }
 
   get isClosableHeader() {
     const header = this.refs.rootElement
@@ -216,16 +216,16 @@ class Header extends BaseComponent {
     const currentScroll = window.scrollY
     const isScrollingDown = currentScroll > lastScroll
     const isHeaderOnTop = currentScroll === 0
-    const mainPageMenuOffset = 100
+    // const mainPageMenuOffset = 100
     this.state.lastScroll = currentScroll
 
-    if (this.isMainPage) {
-      if (this.isMenuOpen && isScrollingDown && currentScroll >= mainPageMenuOffset) {
-        this.closeMenu()
-      } else if (!isScrollingDown && currentScroll < mainPageMenuOffset / 2) {
-        this.openMenu()
-      }
-    }
+    // if (this.isMainPage) {
+    //   if (this.isMenuOpen && isScrollingDown && currentScroll >= mainPageMenuOffset) {
+    //     this.closeMenu()
+    //   } else if (!isScrollingDown && currentScroll < mainPageMenuOffset / 2) {
+    //     this.openMenu()
+    //   }
+    // }
 
     if (isHeaderOnTop) {
       if (this.isFixed) {

--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -136,13 +136,13 @@ class Header extends BaseComponent {
   }
 
   closeOnKeyUp(event) {
-    if (event.code === 'Escape') {
+    if (event.code === 'Escape' && !this.isMainPage) {
       this.closeMenu()
     }
   }
 
   closeOnClickOutSide(event) {
-    if (!event.target.closest('.header__inner')) {
+    if (!event.target.closest('.header__inner') && !this.isMainPage) {
       this.closeMenu()
     }
   }
@@ -216,16 +216,7 @@ class Header extends BaseComponent {
     const currentScroll = window.scrollY
     const isScrollingDown = currentScroll > lastScroll
     const isHeaderOnTop = currentScroll === 0
-    // const mainPageMenuOffset = 100
     this.state.lastScroll = currentScroll
-
-    // if (this.isMainPage) {
-    //   if (this.isMenuOpen && isScrollingDown && currentScroll >= mainPageMenuOffset) {
-    //     this.closeMenu()
-    //   } else if (!isScrollingDown && currentScroll < mainPageMenuOffset / 2) {
-    //     this.openMenu()
-    //   }
-    // }
 
     if (isHeaderOnTop) {
       if (this.isFixed) {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -124,10 +124,6 @@
     visibility 0s;
 }
 
-.header--static .header__inner--menu {
-  position: static;
-}
-
 /* удаляем первое меню, когда показывается второе */
 .header--open > .header__inner--main {
   visibility: hidden;

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -124,6 +124,19 @@
     visibility 0s;
 }
 
+.header--static .header__inner--menu {
+  position: static;
+}
+
+/* удаляем первое меню, когда показывается второе */
+.header--open > .header__inner--main {
+  visibility: hidden;
+}
+
+.header--main.header--open > .header__inner--menu {
+  position: relative;
+}
+
 .header__breadcrumbs {
   min-width: 0;
   line-height: 1.25;
@@ -276,10 +289,6 @@
 .header:not(.header--open)::before {
   opacity: 0;
   visibility: hidden;
-}
-
-.header--static .header__inner--menu {
-  position: static;
 }
 
 .header--static .header__toggle {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -133,6 +133,11 @@
   visibility: hidden;
 }
 
+/* скрываем первое меню на главной */
+.header--main.header--open > .header__inner--main {
+  display: none;
+}
+
 .header--main.header--open > .header__inner--menu {
   position: relative;
 }

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -9,7 +9,7 @@
 ) }}
 
 <main>
-  <div class="container" style="margin-top: calc(({{ collections.articleIndexes.length }} + 1.5) * var(--font-size-xxl));">
+  <div class="container">
     <div class="intro">
       <h1 class="visually-hidden">Дока</h1>
       <div class="intro__pitch">


### PR DESCRIPTION
Решает #985.

Исправления на главной:

- меню всегда открыто и у него `position: relative`;
- скрыто первое меню с помощью `display: none`;
- нет кнопки для закрытия меню;
- при скролле наверх меню не появляется.

На других страницах `visibility: hidden` использую потому, что нам бы его всегда скрывать, когда открывается второе меню. Тогда на пунктах в нём нельзя будет зафокуситься. При этом мы сохраняем его высоту и из-за этого контент на странице не скачет туда-сюда при открытии меню, когда скролишь вверх.

Что осталось исправить и с чем нужна ваша помощь:

- [ ] Проверить нет ли ловушки фокуса в браузерах, кроме Vivaldi.
  Она есть только в Vivaldi, остальные браузеры ведут себя адекватно! Проверьте, пожалуйста, на всякий случай в Safari и в каком-нибудь Chrome на MacOS. Особенно когда используешь клавиатуру для навигации.
- [x] Убедиться, что не осталась лишняя анимация для меню на главной в файлике со стилями.

В Chrome всё выглядит хорошо (как и в Firefox и Edge на Windows).

https://user-images.githubusercontent.com/17615202/228212856-f14d24b1-81f6-406e-b7a5-7ee04cdf3220.mp4

Vivaldi пытается выделиться среди других браузеров 😅

https://user-images.githubusercontent.com/17615202/228197166-7b07cfba-1d19-4610-9494-9f9bb1d402bd.mp4