### PR TITLE
Меняет клавиши навигации

### DIFF
--- a/src/includes/blocks/linked-article.njk
+++ b/src/includes/blocks/linked-article.njk
@@ -10,7 +10,7 @@
         {{ article.title | descriptionMarkdown | safe }}
       </a>
       <div class="linked-article__hotkeys font-theme font-theme--code">
-        <kbd class="linked-article__hotkey hotkey">ctrl</kbd><span class="linked-article__hotkey hotkey linked-article__plus"> + </span><kbd class="linked-article__hotkey hotkey">{{ icon }}</kbd>
+        <kbd class="linked-article__hotkey hotkey">ctrl</kbd><span class="linked-article__hotkey hotkey linked-article__plus"> + </span><kbd class="linked-article__hotkey hotkey">alt</kbd><span class="linked-article__hotkey hotkey linked-article__plus"> + </span><kbd class="linked-article__hotkey hotkey">{{ icon }}</kbd>
       </div>
     </div>
   </aside>

--- a/src/includes/blocks/linked-article.njk
+++ b/src/includes/blocks/linked-article.njk
@@ -10,7 +10,7 @@
         {{ article.title | descriptionMarkdown | safe }}
       </a>
       <div class="linked-article__hotkeys font-theme font-theme--code">
-        <kbd class="linked-article__hotkey hotkey">alt</kbd><span class="linked-article__hotkey hotkey linked-article__plus"> + </span><kbd class="linked-article__hotkey hotkey">{{ icon }}</kbd>
+        <kbd class="linked-article__hotkey hotkey">ctrl</kbd><span class="linked-article__hotkey hotkey linked-article__plus"> + </span><kbd class="linked-article__hotkey hotkey">{{ icon }}</kbd>
       </div>
     </div>
   </aside>

--- a/src/scripts/modules/linked-article-navigation.js
+++ b/src/scripts/modules/linked-article-navigation.js
@@ -1,33 +1,31 @@
 function init() {
-  const [
-    previous,
-    next
-  ] = [
+  const [previous, next] = [
     document.querySelector('.linked-article--previous .linked-article__link'),
     document.querySelector('.linked-article--next .linked-article__link'),
   ]
 
-  // продолжаем, если есть хотя бы одна ссылка
-  if (!(previous || next)) {
+  if (!(previous && next)) {
     return
   }
 
-  function goToArticle(linkElement) {
-    window.location = linkElement.href
-  }
-
-  document.addEventListener('keyup', event => {
-    if (!event.altKey) {
+  function goToArticle(event) {
+    if (!event.ctrlKey) {
       return
     }
 
-    const link = ({
-      'ArrowLeft': previous,
-      'ArrowRight': next
-    })[event.code]
+    const link = {
+      ArrowLeft: previous,
+      ArrowRight: next,
+    }[event.code]
 
-    link && goToArticle(link)
-  })
+    if (!link) {
+      return
+    }
+
+    window.location = link.href
+  }
+
+  document.addEventListener('keyup', goToArticle)
 }
 
 init()

--- a/src/scripts/modules/linked-article-navigation.js
+++ b/src/scripts/modules/linked-article-navigation.js
@@ -9,7 +9,7 @@ function init() {
   }
 
   function goToArticle(event) {
-    if (!event.ctrlKey) {
+    if (!(event.ctrlKey && event.altKey)) {
       return
     }
 


### PR DESCRIPTION
Привет! 

Проблема: навигация между статьями через `alt + стрелка` немного забагована, возникает перескакивание через статью. 

Система на Win11, тестил в Хроме, Яндексе, Firefox.

Это объясняется тем, что у браузеров стандартное поведение на `alt + стрелка` это перейти назад/вперед по истории, из-за чего браузер, в случае стрелки влево, сначала возвращает к прошлой статье, а потом обработчик на `keyup` дополнительно откатывает на материал ещё назад.

https://support.google.com/chrome/answer/157179?hl=ru-ru&co=GENIE.Platform%3DDesktop
https://browser.yandex.ru/help/useful-features/hotkeys.html
https://support.mozilla.org/ru/kb/sochetaniya-klavish

Предлагаю поменять `alt` на универсальный `ctrl`, он не занят у браузеров навигацией, и одновременно этим вернуть `alt` стандартное поведение. Заодно немного порефакторил логику.