### PR TITLE
Добавляет live region и правильные заголовки на страницу поиска 

### DIFF
--- a/src/includes/blocks/search.njk
+++ b/src/includes/blocks/search.njk
@@ -1,7 +1,7 @@
 <form class="header__search search font-theme font-theme--code" method="get" name="search-form" action="/search/" id="search-form">
   <div class="search__control">
-    <label class="visually-hidden" for="search-field">Поиск</label>  
-    <input class="search__input" type="text" name="query" id="search-field" placeholder="Поиск" autocomplete="off">
+    <label class="visually-hidden" for="search-field">Поиск</label>
+    <input class="search__input" type="text" name="query" id="search-field" placeholder="Поиск" autocomplete="off" {% if permalink == "/search/" %}aria-describedby="search-hint"{% endif %}>
 
     <kbd class="hotkey search__key search__key--activate">/</kbd>
     <kbd class="hotkey search__key search__key--enter">↲</kbd>

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -275,6 +275,11 @@ function init() {
     searchField.addEventListener('focus', onFocus, true)
     searchField.addEventListener('blur', onBlur, true)
     searchField.focus()
+    searchField.addEventListener('input', () => {
+      if (!searchField.value) {
+        setLiveRegion(false, searchHits)
+      }
+    })
 
     searchForm.addEventListener('submit', (event) => {
       event.preventDefault()

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -12,6 +12,16 @@ function onBlur() {
   logo.unsetFocusOnElement()
 }
 
+function setLiveRegion(isLiveRegion, element) {
+  if (isLiveRegion) {
+    element.setAttribute('aria-live', 'assertive')
+    element.setAttribute('aria-atomic', 'true')
+  } else {
+    element.removeAttribute('aria-live')
+    element.removeAttribute('aria-atomic')
+  }
+}
+
 class Filter extends BaseComponent {
   constructor({ form }) {
     super()
@@ -125,7 +135,7 @@ class SearchResultOutput extends BaseComponent {
 
         return `
           <article class="search-hit" style="--accent-color: var(--color-base-${hitObject.category})">
-            <h3 class="search-hit__title">
+            <h2 class="search-hit__title">
               <a class="search-hit__link link" href="${hitObject.url}">
                 ${editIcon}${title}
               </a>
@@ -137,23 +147,29 @@ class SearchResultOutput extends BaseComponent {
         `
       },
 
-      hits: (list) => `
-        <ol class="search-result-list base-list">
-          ${list
-            .map(
-              (hitObject) => `
-              <li class="search-result-list__item">
-                ${SearchResultOutput.templates.hit(hitObject)}
-              </li>
-            `
-            )
-            .join('')}
-        </ol>
-      `,
+      hits: (element, list) => {
+        setLiveRegion(false, element)
+        return `
+          <ol class="search-result-list base-list">
+            ${list
+              .map(
+                (hitObject) => `
+                <li class="search-result-list__item">
+                  ${SearchResultOutput.templates.hit(hitObject)}
+                </li>
+              `
+              )
+              .join('')}
+          </ol>
+        `
+      },
 
-      emptyResults: () => `
-        <div class="search-page__empty">Ничего не найдено</div>
-      `,
+      emptyResults: (element) => {
+        setLiveRegion(true, element)
+        return `
+          <div class="search-page__empty">Ничего не найдено</div>
+        `
+      },
     }
   }
 
@@ -164,13 +180,13 @@ class SearchResultOutput extends BaseComponent {
     }
   }
 
-  renderHits(hitObjectList, queryText, SYMBOL_LIMIT) {
+  renderHits(hitObjectList, queryText, resultOutputContainer, SYMBOL_LIMIT) {
     const { element } = this.refs
 
     const result =
       !hitObjectList || hitObjectList.length === 0
-        ? SearchResultOutput.templates.emptyResults()
-        : SearchResultOutput.templates.hits(hitObjectList, queryText, SYMBOL_LIMIT)
+        ? SearchResultOutput.templates.emptyResults(resultOutputContainer)
+        : SearchResultOutput.templates.hits(resultOutputContainer, hitObjectList, queryText, SYMBOL_LIMIT)
 
     element.innerHTML = result
   }
@@ -226,7 +242,7 @@ function init() {
         .search(queryText, filters)
         .then(function (searchObject) {
           const processedHits = processHits(searchObject)
-          searchResultOutput.renderHits(processedHits, queryText, SYMBOL_LIMIT)
+          searchResultOutput.renderHits(processedHits, queryText, searchHits, SYMBOL_LIMIT)
         })
         .catch((error) => {
           console.error(error)

--- a/src/views/search.njk
+++ b/src/views/search.njk
@@ -64,10 +64,11 @@ title: 'Поиск'
     </button>
   </aside>
 
-  <main class="search-page__main">
+  <main class="search-page__main" aria-labelledby="section-name">
+    <h1 class="visually-hidden" id="section-name">Результаты поиска</h1>
     {% include "blocks/search-hits.njk" %}
-    <div class="search__placeholder">
-      Введите что-нибудь в поле для начала поиска
+    <div class="search__placeholder" id="search-hint">
+      Введите что-нибудь в поле для начала поиска, после этого появится результат
     </div>
   </main>
 

--- a/src/views/search.njk
+++ b/src/views/search.njk
@@ -68,7 +68,7 @@ title: 'Поиск'
     <h1 class="visually-hidden" id="section-name">Результаты поиска</h1>
     {% include "blocks/search-hits.njk" %}
     <div class="search__placeholder" id="search-hint">
-      Введите что-нибудь в поле для начала поиска, после этого появится результат
+      Введите текст в поле поиска, и появится список всего, что нашлось
     </div>
   </main>
 


### PR DESCRIPTION
Пулреквест закрывает два ишьюз: #1115 и #1077.

## Что изменилось

- Добавила скрытый `<h1>` с текстом «Результаты поиска».
- Связала `<main>` с этим скрытым заголовком, чтобы пользователи скринридеров знали, как эта область называется и могли быстро переместиться к результатам поиска.
- Сделала ссылки из списка с выдачей `<h2>` вместо `<h3>`.
- Связала текст «Введите что-нибудь в поле для начала поиска» с полем поиска с помощью `aria-describedby`.
- Изменила текст подсказки на «Введите что-нибудь в поле для начала поиска, после этого появится результат».
- Сделала пустую выдачу интерактивной областью, задав элементу с классом `.search__output` атрибуты `aria-live="assertive"` и `aria-atomic="true"`.

## Почему так?

Я прочитала, что с точки зрения UX не ок постоянно объявлять результаты выдачи в случае динамического поиска. Поэтому можно сделать автоматическим только объявление того, что ничего не найдено.

К элементу с классом `.search-page__empty` не прокатит в скрипт добавить `aria-live="assertive"` и `aria-atomic="true"`. Скринридеры не объявляют ничего, если целая нода добавляется в DOM. А вот если добавить скриптом эти атрибуты или текстовое содержимое внутрь тега с ними, то объявляет. Такой вот баг или фича.

Чтобы передать пользователю скринридера, что поиск динамический, можно указать это в подсказке к полю. Поэтому я и изменила этот текст, собственно. Ну и вообще всем хорошо дать понять, что результат появится сам по себе.

## С чем нужна помощь

Давайте обсудим текст подсказки? Я старалась быть краткой, но может можно написать что-то получше. Типа, введите текст в поиск и получите результат. Или как-то так. Может у @skorobaeus есть идеи?

![Красная стрелка указывает на надпись «Введите что-нибудь в поле для начала поиска, после этого появится результат».](https://user-images.githubusercontent.com/17615202/227252367-6aac6709-ac59-4431-947d-2486fb5d888a.png)