### PR TITLE
Добавляет альт в аватарку при его наличии

### DIFF
--- a/src/includes/blocks/person-avatar.njk
+++ b/src/includes/blocks/person-avatar.njk
@@ -1,4 +1,4 @@
-{% macro personAvatar(photoURL, name, category, class) %}
+{% macro personAvatar(photoURL, photoAlt, name, category, class) %}
   {% if (category) %}
     {% set inlineStyles %}
       --accent-color: var(--color-{{ category }})
@@ -10,7 +10,7 @@
     {% if inlineStyles %}style="{{ inlineStyles }}"{% endif %}
   >
     {% if photoURL %}
-      <img class="person-avatar__item person-avatar__image person__avatar" src="{{ photoURL }}" alt="">
+      <img class="person-avatar__item person-avatar__image person__avatar" src="{{ photoURL }}" alt="{% if photoAlt %}{{ photoAlt }}{% endif %}">
     {% else %}
       <div class="person-avatar__item person-avatar__placeholder font-theme font-theme--code" aria-hidden="true">ᴥ</div>
     {% endif %}

--- a/src/views/person.11tydata.js
+++ b/src/views/person.11tydata.js
@@ -69,6 +69,11 @@ module.exports = {
       return person.data.photo
     },
 
+    photoAlt: function (data) {
+      const { person } = data
+      return person.data.photoAlt
+    },
+
     title: function (data) {
       return data.name
     },

--- a/src/views/person.njk
+++ b/src/views/person.njk
@@ -62,6 +62,7 @@
     <div class="person-page__avatar">
       {{ personAvatar(
         photoURL = photo,
+        photoAlt = photoAlt,
         name = name,
         category = mostContributedCategory
       ) }}


### PR DESCRIPTION
Чтобы сделать интерфейс доступнее делает возможность заполнить альтернативное описание аватарки на странице пользователя. Важно: на страницу со списком пользователей такое описание не пробрасывается.

Для того, чтобы проверить, переключитесь на [PR #4345](https://github.com/doka-guide/content/pull/4345) в контенте.

Было:
<img width="1552" alt="Screenshot 2023-03-24 at 16 03 19" src="https://user-images.githubusercontent.com/50330458/227529652-30037e4b-3983-4435-88a4-07d40f9840df.png">

Стало:
<img width="1552" alt="Screenshot 2023-03-24 at 16 04 38" src="https://user-images.githubusercontent.com/50330458/227529703-ab3e25ea-0525-4a7c-9595-05dc7eb34023.png">

В meta на странице пользователя надо добавить опциональный параметр: `photoAlt`, чтобы аватарка получила альтернативное написание. Если параметра не будет, то и описания не будет. 
