### PR TITLE
Исправляет фокус после копировании ссылки на раздел

### DIFF
--- a/src/scripts/modules/toc.js
+++ b/src/scripts/modules/toc.js
@@ -111,7 +111,9 @@ function init() {
               setTimeout(() => {
                 button.disabled = false
                 button.firstElementChild.outerHTML = icon.outerHTML
-                button.focus()
+                if (document.activeElement === document.body || document.activeElement === button) {
+                  button.focus()
+                }
                 status.textContent = undefined
                 status.hidden = true
               }, 1800)


### PR DESCRIPTION
Исправляет #1121

Не уверен, что это адекватное решение, но сделал так потому что после копирования:

1. В Chrome и FF `document.activeElement` - это `body`
2. В Safari - остаётся кнопка

cc @TatianaFokina 