### PR TITLE
Восстанавливает фокус после копирования ссылки

### DIFF
--- a/src/scripts/modules/toc.js
+++ b/src/scripts/modules/toc.js
@@ -111,9 +111,16 @@ function init() {
               setTimeout(() => {
                 button.disabled = false
                 button.firstElementChild.outerHTML = icon.outerHTML
-                if (document.activeElement === document.body || document.activeElement === button) {
+
+                const isParallelCopying = document.querySelector(`${HEADING_COPY_BUTTON_SELECTOR}:disabled`)
+                  ? true
+                  : false
+
+                if (document.activeElement === document.body && !isParallelCopying) {
+                  // восстанавливаем фокус на последней нажатой кнопке
                   button.focus()
                 }
+
                 status.textContent = undefined
                 status.hidden = true
               }, 1800)


### PR DESCRIPTION
Привет! Заметил недавний PR #1122 по ишью #1121, не уверен, что это лучшее решение.

Во-первых, активный элемент после нажатия — это `body`, поэтому не понятно, зачем условие `document.activeElement === button`, а в Safari фокус и так сам вернётся на `button`;
Во-вторых, если скопировать одну ссылку, а потом сразу табнуть (сценарий: передумать) на другую и скопировать ее, то фокус вернется на первую, а должен остаться на второй. Так происходит, потому что фокус в этот момент уже не на `body`, поэтому блок `if` игнорируется.

Предлагаю такое решение: просто смотреть, есть ли параллельное копирование. Если нету, то фокус восстанавливаем обычно, если есть, то игнорируем установку фокуса до последней нажатой кнопки.