### PR TITLE
Добавляет пространство к иконке карандаша

### DIFF
--- a/src/styles/blocks/articles-group.css
+++ b/src/styles/blocks/articles-group.css
@@ -59,6 +59,7 @@
   content: '✎';
   font-family: var(--font-family);
   font-size: var(--font-size-m);
+  letter-spacing: 0.2em;
 }
 
 .article-group__label {


### PR DESCRIPTION
Всегда хотелось «отлепить» иконку карандаша от заголовка статьи, визуально выглядит некрасиво) Предлагаю добавить чуть-чуть расстояния.

Было:

![image](https://user-images.githubusercontent.com/106589280/229602923-98ebe9b4-20c8-4e9d-aac8-1ebadb353556.png)

Стало:

![image](https://user-images.githubusercontent.com/106589280/229602966-98ed2081-8ab9-4d26-b55f-410b40eb0415.png)

Тем более внутри статей такой gap есть:

![image](https://user-images.githubusercontent.com/106589280/229603454-848860a6-779b-433c-853e-875a20d9ad57.png)
