### PR TITLE
Управляет фокусом на странице расширенного поиска

### DIFF
--- a/src/includes/blocks/search.njk
+++ b/src/includes/blocks/search.njk
@@ -1,6 +1,6 @@
 <form class="header__search search font-theme font-theme--code" method="get" name="search-form" action="/search/" id="search-form">
   <div class="search__control">
-    <label class="visually-hidden" for="search-field">Поиск</label>  
+    <label class="visually-hidden" for="search-field">Поиск</label>
     <input class="search__input" type="text" name="query" id="search-field" placeholder="Поиск" autocomplete="off">
 
     <kbd class="hotkey search__key search__key--activate">/</kbd>

--- a/src/scripts/modules/quick-search.js
+++ b/src/scripts/modules/quick-search.js
@@ -67,7 +67,7 @@ class QuickSearch extends BaseComponent {
 
     document.addEventListener('keyup', (event) => {
       if (event.code === 'Slash') {
-        setTimeout(() => {
+        queueMicrotask(() => {
           this.enter()
         })
       }

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -185,6 +185,7 @@ function init() {
   const SEARCH_FORM_SELECTOR = '.search'
   const SEARCH_FIELD_SELECTOR = '.search__input'
   const SEARCH_HITS_SELECTOR = '.search__output'
+  const SEARCH_HIT_LINK_SELECTOR = '.search-hit__link'
 
   const searchForm = document.querySelector(SEARCH_FORM_SELECTOR)
   const searchField = document.querySelector(SEARCH_FIELD_SELECTOR)
@@ -273,12 +274,21 @@ function init() {
 
     document.addEventListener('keyup', (event) => {
       if (event.code === 'Escape') {
-        searchForm.reset()
+        queueMicrotask(() => {
+          searchForm.reset()
+          searchField.focus()
+        })
       }
 
       if (event.code === 'Slash' && document.activeElement !== searchField) {
-        setTimeout(() => {
+        queueMicrotask(() => {
           searchField.focus()
+        })
+      }
+
+      if (event.code === 'Enter' && document.activeElement === searchField) {
+        queueMicrotask(() => {
+          document.querySelector(SEARCH_HIT_LINK_SELECTOR)?.focus()
         })
       }
     })

--- a/src/styles/blocks/search.css
+++ b/src/styles/blocks/search.css
@@ -60,6 +60,7 @@
   visibility: hidden;
 }
 
+.search__input:placeholder-shown ~ .search__key--enter,
 .search__input:not(:focus) ~ .search__key--enter {
   visibility: hidden;
 }


### PR DESCRIPTION
PR по теме #1117

- Добавил фокус на первый элемент выдачи по нажатию `Enter`;
- Добавил фокус на поле ввода по нажатию `Esc` (раньше слетало на body);
- Убрал значок с хоткеем `Enter`, если поле ввода пустое (зачем он там, если поиск не выполнен);
- Переместил фокусы из макротасков в микротаски (кажется, там им лучше?).

Ещё хотел убрать значок с хоткеем `Enter`, если поиск ничего не дал, т.к. опять же нет результатов, к которым можно перейти по нажатию, но как-то не увидел простого решения. Чтобы управлять показом хоткеев от поля ввода в стилях, это нужно, наверное, сперва его инвалидить чем-то в духе `setCustomValidity`, потом уже через `:invalid`... В общем, предлагаю пока так.