### PR TITLE
Убираем текст в начале раздела «На собеседовании»

### DIFF
--- a/src/includes/questions.njk
+++ b/src/includes/questions.njk
@@ -43,10 +43,6 @@
       На собеседовании
     </h2>
 
-    <p class="questions__description">
-      Это партнёрская рубрика, мы выпускаем её совместно с сервисом онлайн-образования <a href="https://practicum.yandex.ru/programming-upskilling/?utm_source=pr&utm_medium=content&utm_campaign=pr_content_programming-upskilling_doka?utm_content=na-sobese" title="Каталог курсов по программированию от Яндекс Практикума">Яндекс Практикум</a>. Приносите вопрос, на который не знаете ответа, в <a href="https://github.com/doka-guide/content/issues?q=is%3Aopen+is%3Aissue+label%3Aсобеседование" title="Все задачи для контента Доки, отфильтрованные по лейблу «собеседование»">задачи</a>, мы разложим всё по полочкам и опубликуем. Если знаете ответ, присылайте <a href="https://github.com/doka-guide/content/blob/main/docs/interviews.md" title="Инструкция по созданию вопросов и ответов для рубрики">пулреквест на GitHub</a>.
-    </p>
-
     <div class="questions__list">
 
       {% for question in questions %}

--- a/src/styles/blocks/answer.css
+++ b/src/styles/blocks/answer.css
@@ -3,12 +3,12 @@
 }
 
 .answer__author {
-  display: flex;
+  display: inline-flex;
   flex-wrap: wrap;
   align-items: baseline;
   gap: 10px 20px;
-  font-size: var(--font-size-headline-4);
-  line-height: var(--font-size-headline-4);
+  font-size: var(--font-size-headline-3);
+  line-height: var(--font-size-headline-3);
 }
 
 .answer__author-roles {
@@ -18,6 +18,10 @@
   --role-border-color: hsl(0 0% 0%);
   align-self: center;
   display: flex;
+}
+
+.answer__author-roles:not(:has(.answer__author-roles-link)) {
+  display: none;
 }
 
 .answer__author-roles-link {
@@ -40,8 +44,8 @@
 .answer__author-name * {
   font-family: 'Spot Mono', monospace;
   font-weight: 300;
-  font-size: var(--font-size-headline-4);
-  line-height: var(--font-line-height-headline-4);
+  font-size: var(--font-size-l);
+  line-height: var(--font-line-height-l);
   letter-spacing: -0.05em;
   text-align: left;
 }

--- a/src/styles/blocks/questions.css
+++ b/src/styles/blocks/questions.css
@@ -3,7 +3,7 @@
   padding: 30px 0 50px;
 }
 
-.question__request:not(:first-child) {
+.question__request {
   margin-top: 50px;
 }
 


### PR DESCRIPTION
Судя по статистике, у нас сейчас 0 переходов на сайт партнёра с этой плашки. При этом она занимает место и снижает привлекательность этой рубрики для потенциальных контрибьюторов. У кого-то могут быть личные консёрны по поводу своего имени под упоминанием определённого бренда.

Предлагаю совсем убрать этот текст, облегчив тем самым интерфейс и повысив привлекательность отвтетов на вопросы в этой рубрике.