### PR TITLE
Фиксит перенос заголовка для Firefox

### DIFF
--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -183,6 +183,7 @@
   grid-row: 1 / 3;
   text-align: right;
   hyphens: auto;
+  word-break: break-word;
 }
 
 .landing__row--interview .preview__img-block {


### PR DESCRIPTION
Фиксит этот заголовок:

![image](https://user-images.githubusercontent.com/29401439/232049758-f070c11b-4a2b-42f8-93cc-5287b804d154.png)
