### PR TITLE
Правит ссылки в подвале

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -2,6 +2,7 @@ require('dotenv').config({ path: '.env' })
 
 const DEFAULT_ENVS = {
   BASE_URL: 'https://dream-job.doka.guide',
+  DEFAULT_URL: 'https://doka.guide',
   SECTIONS: 'dream-job',
   CONTENT_REP_GITHUB: 'https://github.com/doka-guide/content.git',
   CONTENT_HOT_BACKLOG: 'https://github.com/doka-guide/content/milestone/22',
@@ -18,6 +19,7 @@ function getEnv(envKey) {
 
 module.exports = {
   baseUrl: getEnv('BASE_URL'),
+  defaultUrl: getEnv('DEFAULT_URL'),
   mainSections: getEnv('SECTIONS').split(', '),
   contentRepGithub: getEnv('CONTENT_REP_GITHUB'),
   contentRepFolders: getEnv('CONTENT_REP_FOLDERS').split(', '),

--- a/src/includes/blocks/footer.njk
+++ b/src/includes/blocks/footer.njk
@@ -10,10 +10,10 @@
         <a class="footer-list__link link" href="{{ constants.dokaOrgLink }}">GitHub</a>
       </li>
       <li class="footer-list__item">
-        <a class="footer-list__link link" href="/about/">О проекте</a>
+        <a class="footer-list__link link" href="{{ constants.defaultUrl }}/about/">О проекте</a>
       </li>
       <li class="footer-list__item">
-        <a class="footer-list__link link" href="/licenses/">Лицензии</a>
+        <a class="footer-list__link link" href="{{ constants.defaultUrl }}/licenses/">Лицензии</a>
       </li>
     </ul>
   </footer>


### PR DESCRIPTION
На текущей сборке спецпроектов есть проблема в подвалах — битые ссылки.
Можно решить это двумя способами:

1. Быстрый: Поправить ссылки в конкретном спецпроекте
2. Подольше: Добавить в основную ветку, а потом и в ветку текущего спецпроекта условие проверки на URL, и вывода нужного результата.

В этом PR быстрый метод, но я могу переделать его в тот, что подольше.

Плюсы:
- Ссылки в подвале починены и работают
- Появилась ссылка на основную Доку

Минусы:
- Из Доки на спецпроект вернуться нельзя