### PR TITLE
Приносит виджет Baseline

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -200,6 +200,10 @@ module.exports = function (config) {
     return orderedArticleIndexes
   })
 
+  config.addCollection('webFeatures', async () => {
+    return (await import('web-features')).default
+  })
+
   config.setLibrary('md', initMarkdownLibrary())
 
   config.addNunjucksShortcode('readingTime', (text) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,8 @@
         "stylelint": "^14.6.1",
         "stylelint-config-standard": "^25.0.0",
         "terser": "^5.15.1",
-        "transliteration": "^2.2.0"
+        "transliteration": "^2.2.0",
+        "web-features": "^0.4.1"
       },
       "engines": {
         "node": ">=16",
@@ -16750,6 +16751,12 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-features": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-0.4.1.tgz",
+      "integrity": "sha512-L+sP/1snkijvsef57Pn6+BILxDykeZQhlqS2JaYSqe+auajKbVgGzqJjknPpeGGDZVRz6Lfl88o0Mu3ZpD+luQ==",
+      "dev": true
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -29595,6 +29602,12 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-features": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-0.4.1.tgz",
+      "integrity": "sha512-L+sP/1snkijvsef57Pn6+BILxDykeZQhlqS2JaYSqe+auajKbVgGzqJjknPpeGGDZVRz6Lfl88o0Mu3ZpD+luQ==",
+      "dev": true
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "stylelint": "^14.6.1",
     "stylelint-config-standard": "^25.0.0",
     "terser": "^5.15.1",
-    "transliteration": "^2.2.0"
+    "transliteration": "^2.2.0",
+    "web-features": "^0.4.1"
   },
   "dependencies": {
     "@babel/core": "^7.20.12",

--- a/src/includes/blocks/baseline.njk
+++ b/src/includes/blocks/baseline.njk
@@ -1,36 +1,32 @@
 <div class="wdi-browser-compat">
   <span class="wdi-browser-compat__label">Поддержка в браузерах</span>
   <ul class="wdi-browser-compat__items">
-    <li class="wdi-browser-compat__item">
-      <span class="wdi-browser-compat__icon" data-browser="chrome">
-        <span class="visually-hidden">Chrome 112, Поддерживается</span>
-      </span>
-      <span aria-label="Поддерживается" class="wdi-browser-compat__version" data-compat="yes" title="Поддерживается"> 112 </span>
-    </li>
-    <li class="wdi-browser-compat__item">
-      <span class="wdi-browser-compat__icon" data-browser="firefox">
-        <span class="visually-hidden">Firefox 104, За флагом</span>
-      </span>
-      <span aria-label="Behind a flag" title="За флагом" class="wdi-browser-compat__version" data-compat="flag">
-      </span>
-    </li>
-    <li class="wdi-browser-compat__item">
-      <span class="wdi-browser-compat__icon" data-browser="edge">
-        <span class="visually-hidden">Edge, Не поддерживается</span>
-      </span>
-      <span aria-label="Не поддерживается" title="Не поддерживается" class="wdi-browser-compat__version" data-compat="no">
-        <p></p>
-      </span>
-    </li>
-    <li class="wdi-browser-compat__item">
-      <span class="wdi-browser-compat__icon" data-browser="safari">
-        <span class="visually-hidden">Safari preview, Превью</span>
-      </span>
-      <span aria-label="Превью" class="wdi-browser-compat__version" data-compat="preview" title="Превью">
-        <p></p>
-        <p></p>
-      </span>
-    </li>
+    {% for browser in baseline.keys %}
+      <li class="wdi-browser-compat__item">
+        <span class="wdi-browser-compat__icon" data-browser="{{ browser }}">
+          {% if baseline.supported[browser] %}
+              <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, Поддерживается</span>
+            </span>
+            <span aria-label="Поддерживается" title="Поддерживается" class="wdi-browser-compat__version" data-compat="yes">{{ baseline.versions[browser] }}</span>
+          {% elif baseline.flagged[browser] %}
+            <span class="wdi-browser-compat__icon" data-browser="firefox">
+              <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, За флагом</span>
+            </span>
+            <span aria-label="За флагом" title="За флагом" class="wdi-browser-compat__version" data-compat="flag">
+            </span>
+          {% elif baseline.preview[browser] %}
+            <span class="wdi-browser-compat__icon" data-browser="safari">
+              <span class="visually-hidden">{{ baseline.names[browser] }}, Превью</span>
+            </span>
+            <span aria-label="Превью" title="Превью"> class="wdi-browser-compat__version" data-compat="preview"</span>
+          {% else %}
+            <span class="wdi-browser-compat__icon" data-browser="edge">
+              <span class="visually-hidden">{{ baseline.names[browser] }}, Не поддерживается</span>
+            </span>
+            <span aria-label="Не поддерживается" title="Не поддерживается" class="wdi-browser-compat__version" data-compat="no"></span>
+          {% endif %}
+      </li>
+    {% endfor %}
   </ul>
   <a class="wdi-browser-compat__link" href="https://web.dev/baseline/" target="_blank">О Baseline</a>
 </div>

--- a/src/includes/blocks/baseline.njk
+++ b/src/includes/blocks/baseline.njk
@@ -1,0 +1,36 @@
+<div class="wdi-browser-compat">
+  <span class="wdi-browser-compat__label">Поддержка в браузерах</span>
+  <ul class="wdi-browser-compat__items">
+    <li class="wdi-browser-compat__item">
+      <span class="wdi-browser-compat__icon" data-browser="chrome">
+        <span class="visually-hidden">Chrome 112, Поддерживается</span>
+      </span>
+      <span aria-label="Поддерживается" class="wdi-browser-compat__version" data-compat="yes" title="Поддерживается"> 112 </span>
+    </li>
+    <li class="wdi-browser-compat__item">
+      <span class="wdi-browser-compat__icon" data-browser="firefox">
+        <span class="visually-hidden">Firefox 104, За флагом</span>
+      </span>
+      <span aria-label="Behind a flag" title="За флагом" class="wdi-browser-compat__version" data-compat="flag">
+      </span>
+    </li>
+    <li class="wdi-browser-compat__item">
+      <span class="wdi-browser-compat__icon" data-browser="edge">
+        <span class="visually-hidden">Edge, Не поддерживается</span>
+      </span>
+      <span aria-label="Не поддерживается" title="Не поддерживается" class="wdi-browser-compat__version" data-compat="no">
+        <p></p>
+      </span>
+    </li>
+    <li class="wdi-browser-compat__item">
+      <span class="wdi-browser-compat__icon" data-browser="safari">
+        <span class="visually-hidden">Safari preview, Превью</span>
+      </span>
+      <span aria-label="Превью" class="wdi-browser-compat__version" data-compat="preview" title="Превью">
+        <p></p>
+        <p></p>
+      </span>
+    </li>
+  </ul>
+  <a class="wdi-browser-compat__link" href="https://web.dev/baseline/" target="_blank">О Baseline</a>
+</div>

--- a/src/styles/blocks/baseline.css
+++ b/src/styles/blocks/baseline.css
@@ -1,0 +1,116 @@
+.wdi-browser-compat {
+  max-width: 87.5%;
+  align-items: center;
+  color: var(--wdi-text-color, #585b63);
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.wdi-browser-compat__label {
+  color: var(--wdi-text-color, #585b63);
+  flex: 0 0 100%;
+  font-style: normal;
+  margin-right: 1rem;
+  width: 100%;
+}
+
+.wdi-browser-compat__items {
+  display: flex;
+  margin: 1rem 1rem 1rem 0;
+  padding: 0;
+  list-style: none;
+}
+
+.wdi-browser-compat__item {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+
+.wdi-browser-compat__icon {
+  display: inline-block;
+  height: 24px;
+  margin-left: 24px;
+  margin-right: 6px;
+  width: 24px;
+  background-repeat: no-repeat no-repeat;
+  background-position: center center;
+  background-size: cover;
+}
+
+.wdi-browser-compat__icon[data-browser="chrome"] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-10 -10 276 276'%3E%3ClinearGradient id='a' x1='145' x2='34' y1='253' y2='61' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%231e8e3e'/%3E%3Cstop offset='1' stop-color='%2334a853'/%3E%3C/linearGradient%3E%3ClinearGradient id='b' x1='111' x2='222' y1='254' y2='62' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%23fcc934'/%3E%3Cstop offset='1' stop-color='%23fbbc04'/%3E%3C/linearGradient%3E%3ClinearGradient id='c' x1='17' x2='239' y1='80' y2='80' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%23d93025'/%3E%3Cstop offset='1' stop-color='%23ea4335'/%3E%3C/linearGradient%3E%3Ccircle cx='128' cy='128' r='64' fill='%23fff'/%3E%3Cpath fill='url(%23a)' d='M96 183a64 64 0 0 1-23-23L17 64a128 128 0 0 0 111 192l55-96a64 64 0 0 1-87 23Z'/%3E%3Cpath fill='url(%23b)' d='M192 128a64 64 0 0 1-9 32l-55 96A128 128 0 0 0 239 64H128a64 64 0 0 1 64 64Z'/%3E%3Ccircle cx='128' cy='128' r='52' fill='%231a73e8'/%3E%3Cpath fill='url(%23c)' d='M96 73a64 64 0 0 1 32-9h111a128 128 0 0 0-222 0l56 96a64 64 0 0 1 23-87Z'/%3E%3C/svg%3E");
+}
+
+.wdi-browser-compat__icon[data-browser="firefox"] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'%3E%3Cdefs%3E%3CradialGradient id='ff-b' cx='428.5' cy='55.1' r='501' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.1' stop-color='%23ffbd4f'/%3E%3Cstop offset='.2' stop-color='%23ffac31'/%3E%3Cstop offset='.3' stop-color='%23ff9d17'/%3E%3Cstop offset='.3' stop-color='%23ff980e'/%3E%3Cstop offset='.4' stop-color='%23ff563b'/%3E%3Cstop offset='.5' stop-color='%23ff3750'/%3E%3Cstop offset='.7' stop-color='%23f5156c'/%3E%3Cstop offset='.8' stop-color='%23eb0878'/%3E%3Cstop offset='.9' stop-color='%23e50080'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-c' cx='245.4' cy='259.9' r='501' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.3' stop-color='%23960e18'/%3E%3Cstop offset='.3' stop-color='%23b11927' stop-opacity='.7'/%3E%3Cstop offset='.4' stop-color='%23db293d' stop-opacity='.3'/%3E%3Cstop offset='.5' stop-color='%23f5334b' stop-opacity='.1'/%3E%3Cstop offset='.5' stop-color='%23ff3750' stop-opacity='0'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-d' cx='305.8' cy='-58.6' r='363' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.1' stop-color='%23fff44f'/%3E%3Cstop offset='.3' stop-color='%23ffdc3e'/%3E%3Cstop offset='.5' stop-color='%23ff9d12'/%3E%3Cstop offset='.5' stop-color='%23ff980e'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-e' cx='190' cy='390.8' r='238.6' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.3' stop-color='%233a8ee6'/%3E%3Cstop offset='.5' stop-color='%235c79f0'/%3E%3Cstop offset='.7' stop-color='%239059ff'/%3E%3Cstop offset='1' stop-color='%23c139e6'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-f' cx='252.2' cy='201.3' r='126.5' gradientTransform='matrix(1 0 0 1 -48 31)' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.2' stop-color='%239059ff' stop-opacity='0'/%3E%3Cstop offset='.3' stop-color='%238c4ff3' stop-opacity='.1'/%3E%3Cstop offset='.8' stop-color='%237716a8' stop-opacity='.5'/%3E%3Cstop offset='1' stop-color='%236e008b' stop-opacity='.6'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-g' cx='239.1' cy='34.6' r='171.6' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%23ffe226'/%3E%3Cstop offset='.1' stop-color='%23ffdb27'/%3E%3Cstop offset='.3' stop-color='%23ffc82a'/%3E%3Cstop offset='.5' stop-color='%23ffa930'/%3E%3Cstop offset='.7' stop-color='%23ff7e37'/%3E%3Cstop offset='.8' stop-color='%23ff7139'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-h' cx='374' cy='-74.3' r='732.2' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.1' stop-color='%23fff44f'/%3E%3Cstop offset='.5' stop-color='%23ff980e'/%3E%3Cstop offset='.6' stop-color='%23ff5634'/%3E%3Cstop offset='.7' stop-color='%23ff3647'/%3E%3Cstop offset='.9' stop-color='%23e31587'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-i' cx='304.6' cy='7.1' r='536.4' gradientTransform='rotate(84 303 4)' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%23fff44f'/%3E%3Cstop offset='.1' stop-color='%23ffe847'/%3E%3Cstop offset='.2' stop-color='%23ffc830'/%3E%3Cstop offset='.3' stop-color='%23ff980e'/%3E%3Cstop offset='.4' stop-color='%23ff8b16'/%3E%3Cstop offset='.5' stop-color='%23ff672a'/%3E%3Cstop offset='.6' stop-color='%23ff3647'/%3E%3Cstop offset='.7' stop-color='%23e31587'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-j' cx='235' cy='98.1' r='457.1' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.1' stop-color='%23fff44f'/%3E%3Cstop offset='.5' stop-color='%23ff980e'/%3E%3Cstop offset='.6' stop-color='%23ff5634'/%3E%3Cstop offset='.7' stop-color='%23ff3647'/%3E%3Cstop offset='.9' stop-color='%23e31587'/%3E%3C/radialGradient%3E%3CradialGradient id='ff-k' cx='355.7' cy='124.9' r='500.3' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.1' stop-color='%23fff44f'/%3E%3Cstop offset='.2' stop-color='%23ffe141'/%3E%3Cstop offset='.5' stop-color='%23ffaf1e'/%3E%3Cstop offset='.6' stop-color='%23ff980e'/%3E%3C/radialGradient%3E%3ClinearGradient id='ff-a' x1='446.9' y1='76.8' x2='47.9' y2='461.8' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.1' stop-color='%23fff44f'/%3E%3Cstop offset='.1' stop-color='%23ffe847'/%3E%3Cstop offset='.2' stop-color='%23ffc830'/%3E%3Cstop offset='.4' stop-color='%23ff980e'/%3E%3Cstop offset='.4' stop-color='%23ff8b16'/%3E%3Cstop offset='.5' stop-color='%23ff672a'/%3E%3Cstop offset='.5' stop-color='%23ff3647'/%3E%3Cstop offset='.7' stop-color='%23e31587'/%3E%3C/linearGradient%3E%3ClinearGradient id='ff-l' x1='442.1' y1='74.8' x2='102.6' y2='414.3' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='.2' stop-color='%23fff44f' stop-opacity='.8'/%3E%3Cstop offset='.3' stop-color='%23fff44f' stop-opacity='.6'/%3E%3Cstop offset='.5' stop-color='%23fff44f' stop-opacity='.2'/%3E%3Cstop offset='.6' stop-color='%23fff44f' stop-opacity='0'/%3E%3C/linearGradient%3E%3C/defs%3E%3Cpath d='M479 166c-11-25-32-52-49-60a249 249 0 0 1 25 73c-27-68-73-95-111-155a255 255 0 0 1-8-14 44 44 0 0 1-4-9 1 1 0 0 0 0-1 1 1 0 0 0-1 0c-60 35-81 101-83 134a120 120 0 0 0-66 25 71 71 0 0 0-6-5 111 111 0 0 1-1-58c-25 11-44 29-58 44-9-12-9-52-8-60l-8 4a175 175 0 0 0-24 21 210 210 0 0 0-22 26 203 203 0 0 0-32 73l-1 2-2 15a229 229 0 0 0-4 34v1a240 240 0 0 0 477 40l1-9c5-41 0-84-15-121zM202 355l3 1-3-1zm55-145zm198-31z' fill='url(%23ff-a)'/%3E%3Cpath d='M479 166c-11-25-32-52-49-60 14 26 22 53 25 72v1a207 207 0 0 1-206 279c-113-3-212-87-231-197-3-17 0-26 2-40-2 11-3 14-4 34v1a240 240 0 0 0 477 40l1-9c5-41 0-84-15-121z' fill='url(%23ff-b)'/%3E%3Cpath d='M479 166c-11-25-32-52-49-60 14 26 22 53 25 72v1a207 207 0 0 1-206 279c-113-3-212-87-231-197-3-17 0-26 2-40-2 11-3 14-4 34v1a240 240 0 0 0 477 40l1-9c5-41 0-84-15-121z' fill='url(%23ff-c)'/%3E%3Cpath d='m362 195 1 1a130 130 0 0 0-22-29C266 92 322 5 331 0c-60 35-81 101-83 134l9-1c45 0 84 25 105 62z' fill='url(%23ff-d)'/%3E%3Cpath d='M257 210c-1 6-22 26-29 26-68 0-80 41-80 41 3 35 28 64 57 79l4 2 7 3a107 107 0 0 0 31 6c120 6 143-143 57-186 22-4 45 5 58 14-21-37-60-62-105-62l-9 1a120 120 0 0 0-66 25l17 16c16 16 58 33 58 35z' fill='url(%23ff-e)'/%3E%3Cpath d='M257 210c-1 6-22 26-29 26-68 0-80 41-80 41 3 35 28 64 57 79l4 2 7 3a107 107 0 0 0 31 6c120 6 143-143 57-186 22-4 45 5 58 14-21-37-60-62-105-62l-9 1a120 120 0 0 0-66 25l17 16c16 16 58 33 58 35z' fill='url(%23ff-f)'/%3E%3Cpath d='m171 151 5 3a111 111 0 0 1-1-58c-25 11-44 29-58 44 1 0 36 0 54 11z' fill='url(%23ff-g)'/%3E%3Cpath d='M18 261a242 242 0 0 0 231 197 207 207 0 0 0 206-279c8 56-20 110-64 146-86 71-169 43-186 31l-3-1c-50-24-71-70-67-110-42 0-57-35-57-35s38-28 89-4c46 22 90 4 90 4 0-2-42-19-58-35l-17-16a71 71 0 0 0-6-5l-5-3c-18-11-52-11-54-11-9-12-9-51-8-60l-8 4a175 175 0 0 0-24 21 210 210 0 0 0-22 26 203 203 0 0 0-32 73c0 1-9 38-5 57z' fill='url(%23ff-h)'/%3E%3Cpath d='M341 167a130 130 0 0 1 22 29 46 46 0 0 1 4 3c55 50 26 121 24 126 44-36 72-90 64-146-27-68-73-95-111-155a255 255 0 0 1-8-14 44 44 0 0 1-4-9 1 1 0 0 0 0-1 1 1 0 0 0-1 0c-9 5-65 92 10 167z' fill='url(%23ff-i)'/%3E%3Cpath d='M367 199a46 46 0 0 0-4-3l-1-1c-13-9-36-18-58-15 86 44 63 193-57 187a107 107 0 0 1-31-6 131 131 0 0 1-11-5c17 12 99 39 186-31 2-5 31-76-24-126z' fill='url(%23ff-j)'/%3E%3Cpath d='M148 277s12-41 80-41c7 0 28-20 29-26s-44 18-90-4c-51-24-89 4-89 4s15 35 57 35c-4 40 16 85 67 110l3 1c-29-15-54-44-57-79z' fill='url(%23ff-k)'/%3E%3Cpath d='M479 166c-11-25-32-52-49-60a249 249 0 0 1 25 73c-27-68-73-95-111-155a255 255 0 0 1-8-14 44 44 0 0 1-4-9 1 1 0 0 0 0-1 1 1 0 0 0-1 0c-60 35-81 101-83 134l9-1c45 0 84 25 105 62-13-9-36-18-58-14 86 43 63 192-57 186a107 107 0 0 1-31-6 131 131 0 0 1-11-5l-3-1 3 1c-29-15-54-44-57-79 0 0 12-41 80-41 7 0 28-20 29-26 0-2-42-19-58-35l-17-16a71 71 0 0 0-6-5 111 111 0 0 1-1-58c-25 11-44 29-58 44-9-12-9-52-8-60l-8 4a175 175 0 0 0-24 21 210 210 0 0 0-22 26 203 203 0 0 0-32 73l-1 2-2 15a279 279 0 0 0-4 34v1a240 240 0 0 0 477 40l1-9c5-41 0-84-15-121zm-24 13z' fill='url(%23ff-l)'/%3E%3C/svg%3E");
+}
+
+.wdi-browser-compat__icon[data-browser="edge"] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='0 0 27600 27600'%3E%3ClinearGradient id='A' gradientUnits='userSpaceOnUse'/%3E%3ClinearGradient id='B' x1='6870' x2='24704' y1='18705' y2='18705' xlink:href='%23A'%3E%3Cstop offset='0' stop-color='%230c59a4'/%3E%3Cstop offset='1' stop-color='%23114a8b'/%3E%3C/linearGradient%3E%3ClinearGradient id='C' x1='16272' x2='5133' y1='10968' y2='23102' xlink:href='%23A'%3E%3Cstop offset='0' stop-color='%231b9de2'/%3E%3Cstop offset='.16' stop-color='%231595df'/%3E%3Cstop offset='.67' stop-color='%230680d7'/%3E%3Cstop offset='1' stop-color='%230078d4'/%3E%3C/linearGradient%3E%3CradialGradient id='D' cx='16720' cy='18747' r='9538' xlink:href='%23A'%3E%3Cstop offset='.72' stop-opacity='0'/%3E%3Cstop offset='.95' stop-opacity='.53'/%3E%3Cstop offset='1'/%3E%3C/radialGradient%3E%3CradialGradient id='E' cx='7130' cy='19866' r='14324' gradientTransform='matrix(.14843 -.98892 .79688 .1196 -8759 25542)' xlink:href='%23A'%3E%3Cstop offset='.76' stop-opacity='0'/%3E%3Cstop offset='.95' stop-opacity='.5'/%3E%3Cstop offset='1'/%3E%3C/radialGradient%3E%3CradialGradient id='F' cx='2523' cy='4680' r='20243' gradientTransform='matrix(-.03715 .99931 -2.12836 -.07913 13579 3530)' xlink:href='%23A'%3E%3Cstop offset='0' stop-color='%2335c1f1'/%3E%3Cstop offset='.11' stop-color='%2334c1ed'/%3E%3Cstop offset='.23' stop-color='%232fc2df'/%3E%3Cstop offset='.31' stop-color='%232bc3d2'/%3E%3Cstop offset='.67' stop-color='%2336c752'/%3E%3C/radialGradient%3E%3CradialGradient id='G' cx='24247' cy='7758' r='9734' gradientTransform='matrix(.28109 .95968 -.78353 .22949 24510 -16292)' xlink:href='%23A'%3E%3Cstop offset='0' stop-color='%2366eb6e'/%3E%3Cstop offset='1' stop-color='%2366eb6e' stop-opacity='0'/%3E%3C/radialGradient%3E%3Cpath id='H' d='M24105 20053a9345 9345 0 01-1053 472 10202 10202 0 01-3590 646c-4732 0-8855-3255-8855-7432 0-1175 680-2193 1643-2729-4280 180-5380 4640-5380 7253 0 7387 6810 8137 8276 8137 791 0 1984-230 2704-456l130-44a12834 12834 0 006660-5282c220-350-168-757-535-565z'/%3E%3Cpath id='I' d='M11571 25141a7913 7913 0 01-2273-2137 8145 8145 0 01-1514-4740 8093 8093 0 013093-6395 8082 8082 0 011373-859c312-148 846-414 1554-404a3236 3236 0 012569 1297 3184 3184 0 01636 1866c0-21 2446-7960-8005-7960-4390 0-8004 4166-8004 7820 0 2319 538 4170 1212 5604a12833 12833 0 007684 6757 12795 12795 0 003908 610c1414 0 2774-233 4045-656a7575 7575 0 01-6278-803z'/%3E%3Cpath id='J' d='M16231 15886c-80 105-330 250-330 566 0 260 170 512 472 723 1438 1003 4149 868 4156 868a5954 5954 0 003027-839 6147 6147 0 001133-850 6180 6180 0 001910-4437c26-2242-796-3732-1133-4392-2120-4141-6694-6525-11668-6525-7011 0-12703 5635-12798 12620 47-3654 3679-6605 7996-6605 350 0 2346 34 4200 1007 1634 858 2490 1894 3086 2921 618 1067 728 2415 728 2952s-271 1333-780 1990z'/%3E%3Cuse fill='url(%23B)' xlink:href='%23H'/%3E%3Cuse fill='url(%23D)' opacity='.35' xlink:href='%23H'/%3E%3Cuse fill='url(%23C)' xlink:href='%23I'/%3E%3Cuse fill='url(%23E)' opacity='.4' xlink:href='%23I'/%3E%3Cuse fill='url(%23F)' xlink:href='%23J'/%3E%3Cuse fill='url(%23G)' xlink:href='%23J'/%3E%3C/svg%3E");
+}
+
+.wdi-browser-compat__icon[data-browser="safari"] {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' viewBox='195 190 135 135'%3E%3Cdefs%3E%3ClinearGradient id='s-a' x1='132.6' x2='134.4' y1='111.7' y2='-105.3' xlink:href='%23s-b'%3E%3Cstop offset='0' stop-color='%23d2d2d2' /%3E%3Cstop offset='.5' stop-color='%23f2f2f2' /%3E%3Cstop offset='1' stop-color='%23fff' /%3E%3C/linearGradient%3E%3ClinearGradient id='s-b' gradientUnits='userSpaceOnUse' /%3E%3ClinearGradient id='s-c' x1='65.4' x2='67.4' y1='115.7' y2='17.1' xlink:href='%23s-b'%3E%3Cstop offset='0' stop-color='%23005ad5' /%3E%3Cstop offset='.2' stop-color='%230875f0' /%3E%3Cstop offset='.3' stop-color='%23218cee' /%3E%3Cstop offset='.6' stop-color='%2327a5f3' /%3E%3Cstop offset='.8' stop-color='%2325aaf2' /%3E%3Cstop offset='1' stop-color='%2321aaef' /%3E%3C/linearGradient%3E%3ClinearGradient id='s-d' x1='158.7' x2='176.3' y1='96.7' y2='79.5' xlink:href='%23s-b'%3E%3Cstop offset='0' stop-color='%23c72e24' /%3E%3Cstop offset='1' stop-color='%23fd3b2f' /%3E%3C/linearGradient%3E%3CradialGradient id='s-i' cx='-69.9' cy='69.3' r='54' gradientTransform='matrix(.9 -.01 .04 2.72 -9 -120)' xlink:href='%23s-b'%3E%3Cstop offset='0' stop-color='%2324a5f3' stop-opacity='0' /%3E%3Cstop offset='1' stop-color='%231e8ceb' /%3E%3C/radialGradient%3E%3CradialGradient id='s-j' cx='109.3' cy='13.8' r='93.1' gradientTransform='matrix(-.02 1.1 -1.04 -.02 137 -115)' xlink:href='%23s-b'%3E%3Cstop offset='0' stop-opacity='0' /%3E%3Cstop offset='1' stop-color='%235488d6' stop-opacity='0' /%3E%3Cstop offset='1' stop-color='%235d96eb' /%3E%3C/radialGradient%3E%3C/defs%3E%3Crect width='220' height='220' x='22' y='-107' fill='url(%23s-a)' ry='49' transform='matrix(.57 0 0 .57 187 256)' /%3E%3Cg transform='translate(194 190)'%3E%3Ccircle cx='67.8' cy='67.7' fill='url(%23s-c)' paint-order='stroke fill markers' r='54' /%3E%3Ccircle cx='-69.9' cy='69.3' fill='url(%23s-i)' transform='translate(138 -2)' r='54' /%3E%3C/g%3E%3Cellipse cx='120' cy='14.2' fill='url(%23s-j)' rx='93.1' ry='93.7' transform='matrix(.58 0 0 .58 192 250)' /%3E%3Cg transform='matrix(.58 0 0 .57 197 182)'%3E%3Cpath fill='%23cac7c8' d='M46 192h1l72-48-7-9-66 57Z' /%3E%3Cpath fill='%23fbfffc' d='M46 191v1l66-57-7-9-59 65Z' /%3E%3Cpath fill='url(%23s-d)' d='m119 144-7-9 66-57-59 66Z' /%3E%3Cpath fill='%23fb645c' d='m105 126 7 9 66-57-1-1-72 49Z' /%3E%3C/g%3E%3Cpath stroke='%23fff' stroke-linecap='round' stroke-miterlimit='1' stroke-width='1.3' d='m287 278 3-2m-12-17 8-2m-8-3h4m-4-13 8 2m-8 3h4m-1-13 7 3m-4-11 7 4m-2-11 6 6m0-12 6 7m1-11 4 6m4-10 3 7m5-9 2 7m15-7-1 7m10-5-3 7m11-4-4 7m11-2-5 6m16 7-7 4m10 4-7 3m10 6-8 1m8 16-8-2m5 10-7-3m4 11-7-4m2 11-6-5m0 11-5-6m-2 11-4-7m-4 11-3-8m-6 10-1-8m-16 8 2-8m-10 5 3-7m-11 4 4-7m-11 2 5-6m-8 3 3-3m4 8 2-3m5 8 2-4m6 7 1-4m8 5v-4m8 4v-4m9 3-1-4m9 1-2-4m9 0-2-4m9-2-3-3m8-4-3-2m8-5-4-2m7-6-4-1m5-8h-4m4-8h-4m3-9-4 1m1-9-4 2m-1-9-3 2m-2-9-3 3m-4-8-2 3m-5-8-2 4m-6-6-1 3m-8-5v4m-8-4v4m-9-2 1 3m-9 0 2 3m-9 1 2 3m-9 2 3 3m-8 4 3 2m-8 5 4 2m-7 6 4 1m-4 25 4-1m-2 5 7-3m-6 7 4-2m-2 6 7-4m-13-21h8m41-41v-8m0 99v-8m49-42h-8' transform='translate(-65 8)' /%3E%3C/svg%3E");
+}
+
+.wdi-browser-compat__version {
+  box-sizing: border-box;
+  --size-2: clamp(0.75rem, 0.71rem + 0.18vw, 0.875rem);
+  background-repeat: no-repeat no-repeat;
+  background-position: center center;
+  border-radius: 10000px;
+  display: inline-block;
+  font-size: var(--size-2);
+  height: 24px;
+  line-height: 24px;
+  min-width: 24px;
+  text-align: center;
+  padding-inline: 0.5ch;
+}
+
+.wdi-browser-compat__version[data-compat="yes"] {
+  background: var(--wdi-success-bg-color, #e9f6ed);
+  color: var(--wdi-success-color, #0d652d);
+}
+
+.wdi-browser-compat__version[data-compat="flag"] {
+  background-color: var(--wdi-warn-bg-color, #fff5e3);
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='14' viewBox='0 0 12 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 14V0H7L7.5 2H12V10H7L6.5 8H1.5V14H0ZM8.16667 8.5H10.5V3.5H6.33333L5.83333 1.5H1.5V6.5H7.66667L8.16667 8.5Z' fill='%23F29900'/%3E%3C/svg%3E%0A");
+  color: var(--wdi-warn-color, #c34900);
+}
+
+.wdi-browser-compat__version[data-compat="no"] {
+  background-color: var(--wdi-error-bg-color, #fce8e8);
+  background-image: url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 10 10' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.0625 10L0 8.9375L3.9375 5L0 1.0625L1.0625 0L5 3.9375L8.9375 0L10 1.0625L6.0625 5L10 8.9375L8.9375 10L5 6.0625L1.0625 10Z' fill='%23A50E0E'/%3E%3C/svg%3E%0A");
+  color: var(--wdi-error-color, #a50e0e);
+}
+
+.wdi-browser-compat__version[data-compat="preview"] {
+  background-color: var(--wdi-warn-bg-color, #fff5e3);
+  background-image: url("data:image/svg+xml,%3Csvg width='18' height='12' viewBox='0 0 18 12' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M9 9.5C9.97222 9.5 10.7986 9.15972 11.4792 8.47917C12.1597 7.79861 12.5 6.97222 12.5 6C12.5 5.02778 12.1597 4.20139 11.4792 3.52083C10.7986 2.84028 9.97222 2.5 9 2.5C8.02778 2.5 7.20139 2.84028 6.52083 3.52083C5.84028 4.20139 5.5 5.02778 5.5 6C5.5 6.97222 5.84028 7.79861 6.52083 8.47917C7.20139 9.15972 8.02778 9.5 9 9.5ZM9 8C8.44444 8 7.97222 7.80556 7.58333 7.41667C7.19444 7.02778 7 6.55556 7 6C7 5.44444 7.19444 4.97222 7.58333 4.58333C7.97222 4.19444 8.44444 4 9 4C9.55556 4 10.0278 4.19444 10.4167 4.58333C10.8056 4.97222 11 5.44444 11 6C11 6.55556 10.8056 7.02778 10.4167 7.41667C10.0278 7.80556 9.55556 8 9 8ZM9 12C7.0195 12 5.21535 11.4549 3.58754 10.3646C1.95974 9.27431 0.763889 7.81944 0 6C0.763889 4.18056 1.95974 2.72569 3.58754 1.63542C5.21535 0.545139 7.0195 0 9 0C10.9805 0 12.7847 0.545139 14.4125 1.63542C16.0403 2.72569 17.2361 4.18056 18 6C17.2361 7.81944 16.0403 9.27431 14.4125 10.3646C12.7847 11.4549 10.9805 12 9 12ZM9 10.5C10.5556 10.5 11.9931 10.0972 13.3125 9.29167C14.6319 8.48611 15.6458 7.38889 16.3542 6C15.6458 4.61111 14.6319 3.51389 13.3125 2.70833C11.9931 1.90278 10.5556 1.5 9 1.5C7.44444 1.5 6.00694 1.90278 4.6875 2.70833C3.36806 3.51389 2.35417 4.61111 1.64583 6C2.35417 7.38889 3.36806 8.48611 4.6875 9.29167C6.00694 10.0972 7.44444 10.5 9 10.5Z' fill='%23F29900'/%3E%3C/svg%3E%0A");
+  color: var(--wdi-warn-color, #c34900);
+}
+
+.wdi-browser-compat__link {
+  flex: 0 0 100%;
+  margin-left: 0;
+  color: currentColor;
+}
+
+@media (min-width: 50em) {
+  .wdi-browser-compat {
+    flex-wrap: nowrap;
+  }
+
+  .wdi-browser-compat__label {
+    flex: none;
+    margin-bottom: 0;
+    width: auto;
+  }
+
+  .wdi-browser-compat__link {
+    flex: none;
+    margin-left: auto;
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -87,3 +87,4 @@
 @import 'blocks/color-picker.css';
 @import 'blocks/subscribe-popup.css';
 @import 'blocks/subscribe-page.css';
+@import 'blocks/baseline.css';

--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -32,6 +32,13 @@ function hasTag(tags, tag) {
   return (tags || []).includes(tag)
 }
 
+function assignGreaterValue(map, item, key) {
+  if (!Number.isNaN(item[key]) && Number(item[key]) > map[key]) {
+    map[key] = Number(item[key])
+  }
+  return map
+}
+
 // TODO: вынести эту функцию в отдельный файл и переиспользовать в `views.11tydata.js`
 function transformArticleData(article) {
   const section = article.filePathStem.split('/')[1]
@@ -234,9 +241,56 @@ module.exports = {
       return hasTag(doc.data.tags, 'placeholder')
     },
 
-    isBaseline: function (data) {
+    hasBaseline: function (data) {
       const { doc } = data
-      return hasTag(doc.data.tags, 'baseline')
+      return Object.keys(doc.data).includes('baseline')
+    },
+
+    baseline: function (data) {
+      const { doc, collections, hasBaseline } = data
+      const { webFeatures } = collections
+      if (hasBaseline) {
+        const keys = ['chrome', 'edge', 'firefox', 'safari']
+        const names = { chrome: 'Chrome', edge: 'Edge', firefox: 'Firefox', safari: 'Safari' }
+        const versions = doc.data.baseline
+          .filter((g) => Object.keys(webFeatures[g.group]).includes('status'))
+          .map((g) => {
+            return webFeatures[g.group].status.support
+          })
+          .reduce(
+            (map, item) => {
+              for (const key of keys) {
+                assignGreaterValue(map, item, key)
+              }
+              return map
+            },
+            { chrome: 0, edge: 0, firefox: 0, safari: 0 }
+          )
+        const supported = doc.data.baseline
+          .filter((g) => webFeatures[g.group].is_baseline)
+          .reduce(
+            (map, item) => {
+              for (const key of keys) {
+                if (!item[key]) {
+                  map[key] = false
+                }
+              }
+              return map
+            },
+            { chrome: true, edge: true, firefox: true, safari: true }
+          )
+        const flagged = { chrome: false, edge: false, firefox: false, safari: false }
+        const preview = { chrome: false, edge: false, firefox: false, safari: false }
+        return {
+          keys,
+          names,
+          versions,
+          flagged,
+          supported,
+          preview,
+        }
+      }
+      return {}
     },
 
     documentTitle: function (data) {

--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -234,6 +234,11 @@ module.exports = {
       return hasTag(doc.data.tags, 'placeholder')
     },
 
+    isBaseline: function (data) {
+      const { doc } = data
+      return hasTag(doc.data.tags, 'baseline')
+    },
+
     documentTitle: function (data) {
       // удаляем символы обратных кавычек html-тегов из markdown
       const title = data.title.replace(/`/g, '')

--- a/src/views/doc.njk
+++ b/src/views/doc.njk
@@ -37,7 +37,7 @@
           {% if description %}
             <p class="article__description">
               {{ description | descriptionMarkdown | safe }}
-            </p]>
+            </p>
           {% endif %}
 
           <p class="article__read-time">
@@ -101,6 +101,9 @@
         <div class="article__content doc__wrapper">
           <div class="article__content-inner content">
             {{ doc.templateContent | safe }}
+            {% if isBaseline %}
+              {% include "blocks/baseline.njk" %}
+            {% endif %}
             {% include "practices.njk" %}
             {% include "questions.njk" %}
           </div>

--- a/src/views/doc.njk
+++ b/src/views/doc.njk
@@ -101,7 +101,7 @@
         <div class="article__content doc__wrapper">
           <div class="article__content-inner content">
             {{ doc.templateContent | safe }}
-            {% if isBaseline %}
+            {% if hasBaseline %}
               {% include "blocks/baseline.njk" %}
             {% endif %}
             {% include "practices.njk" %}


### PR DESCRIPTION
Заверстала блок для вывода данных о поддержке браузерами фичи. 

Выглядит пока так 

<img width="859" alt="CleanShot 2023-05-11 at 14 24 01@2x" src="https://github.com/doka-guide/platform/assets/13676514/a210d03d-ad1f-4ac4-94d0-1e4dae896e36">

Выбрала «компактную» форму. Стащила с web.dev. «Официального» виджета пока нет. Верстают кто как.

В текущем варианте видно все 4 возможных статуса поддержки: 
- Поддерживается
- Не поддерживается
- За флагом
- В превью

Оставила ссылочку на страницу описания проекта чтобы у людей не было вопроса откуда инфа.

Чтобы потестить пока что можно добавить любой статье тег baseline. Виджет будет внизу страницы, под подсказками.