### PR TITLE
Fix: убирает отступ в лого на 404 странице

### DIFF
--- a/src/styles/blocks/logo.css
+++ b/src/styles/blocks/logo.css
@@ -124,7 +124,6 @@
 
 .logo__text--contrast {
   border: 1px var(--logo-border-color) solid;
-  padding-bottom: 0;
 }
 
 .logo__text::first-letter {


### PR DESCRIPTION
Убирает отступ снизу в логотипе 404-й страницы, чтобы лого везде был одинаковым.

Было:
<img width="1381" alt="Screenshot 2023-05-17 at 18 51 49" src="https://github.com/doka-guide/platform/assets/50330458/c97e7e79-4d94-4b4d-ad3d-c264d7041bd1">

Стало:
<img width="1381" alt="Screenshot 2023-05-17 at 18 51 59" src="https://github.com/doka-guide/platform/assets/50330458/38f18af4-63f8-4c94-986a-993382704897">

Для теста добавьте к адресу любой страницы на превью и на проде в URL: 404
