### PR TITLE
Делает `id` у кнопки копирования секции уникальным и изменяет её текст

### DIFF
--- a/src/transforms/headings-anchor-transform.js
+++ b/src/transforms/headings-anchor-transform.js
@@ -5,12 +5,12 @@
 
 function createButtonMarkup(id, headingText) {
   return `
-    <button class="article-heading__copy-button" data-anchor="#${id}" aria-describedby="status">
+    <button class="article-heading__copy-button" data-anchor="#${id}" aria-describedby="status-${id}">
       <svg class="article-heading__icon" width="24" height="24" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
         <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
       </svg>
-      <span class="visually-hidden">Скопировать ссылку на секцию "${headingText.replace(/(<|>)/g, '')}"</span>
+      <span class="visually-hidden">Скопировать ссылку "${headingText.replace(/(<|>)/g, '')}"</span>
     </button>
   `
 }
@@ -35,7 +35,7 @@ module.exports = function (window) {
 
       const copier = window.document.createElement('span')
       const buttonHTML = createButtonMarkup(id, headingText)
-      const statusHTML = '<span id="status" class="article-heading__status" role="status">Скопировано</span>'
+      const statusHTML = `<span role="status" id="status-${id}" class="article-heading__status">Скопировано</span>`
       const space = window.document.createTextNode(' ')
 
       copier.innerHTML = buttonHTML + statusHTML


### PR DESCRIPTION
Решение в рамках ишью #1149. Пропустила, что у `aria-describedby` одинаковые значений, а это критическая ошибка. Для уникальности значения просто добавляю к `status` такой же текст, как у заголовков.