### PR TITLE
Добавляет `aria-labelledby` для `<aside>` на странице материала

### DIFF
--- a/src/includes/blocks/linked-article.njk
+++ b/src/includes/blocks/linked-article.njk
@@ -1,7 +1,8 @@
 {% macro linkedArticle(article, type = 'previous') %}
   {% set icon = '←' if type === 'previous' else '→' %}
 
-  <aside class="linked-article linked-article--{{ type }}" style="--accent-color: var(--color-{{ article.section }})">
+  <aside class="linked-article linked-article--{{ type }}" style="--accent-color: var(--color-{{ article.section }})" aria-labelledby="article-{{ type }}">
+    <span class="visually-hidden" id="article-{{ type }}">{% if type === 'next' %}Следующая{% else %}Предыдущая{% endif %} статья</span>
     <div class="linked-article__icon font-theme font-theme--code" aria-hidden="true">
       {{ icon }}
     </div>

--- a/src/includes/blocks/linked-article.njk
+++ b/src/includes/blocks/linked-article.njk
@@ -2,7 +2,7 @@
   {% set icon = '←' if type === 'previous' else '→' %}
 
   <aside class="linked-article linked-article--{{ type }}" style="--accent-color: var(--color-{{ article.section }})" aria-labelledby="article-{{ type }}">
-    <span class="visually-hidden" id="article-{{ type }}">{% if type === 'next' %}Следующая{% else %}Предыдущая{% endif %} статья</span>
+    <span class="visually-hidden" id="article-{{ type }}">{% if type === 'next' %}Следующий{% else %}Предыдущий{% endif %} материал</span>
     <div class="linked-article__icon font-theme font-theme--code" aria-hidden="true">
       {{ icon }}
     </div>

--- a/src/views/doc.njk
+++ b/src/views/doc.njk
@@ -108,7 +108,8 @@
             {% include "questions.njk" %}
           </div>
 
-          <aside class="doc__feedback-form">
+          <aside class="doc__feedback-form" aria-labelledby="feedback">
+            <span class="visually-hidden" id="feedback">Оценка материала</span>
             {% include "feedback-form.njk" %}
           </aside>
 


### PR DESCRIPTION
Решила проблему, описанную в ишью #1150. Теперь у всех трёх `<aside>` на странице есть скрытое имя. По правилам у повторяющихся ориентиров должно быть уникальное имя, чтобы пользователи вспомогательных технологий, открыв меню с ними, быстро смогли сориентироваться между одинаковыми.