### PR TITLE
Добавляет отступ между параграфами для блочных цитат

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -71,6 +71,10 @@
   background-color: var(--accent-color);
 }
 
+.content > blockquote > p + p {
+  margin-block-start: 5px;
+}
+
 .content > img,
 .content > video,
 .content > audio,


### PR DESCRIPTION
Добавила отступ между параграфами в блочных цитатах такого вида:

```
> Я блочная 
> цитата
> 
> Я её автор, например
```

Пока сделала такого же размера, как отступ между параграфами в `<aside>`, чтобы не выбивалось.

Соседний ПР [#17](https://github.com/doka-guide/landings/pull/17)