### PR TITLE
Улучшает контрастность клавиатурных сокращений

### DIFF
--- a/src/styles/blocks/hotkey.css
+++ b/src/styles/blocks/hotkey.css
@@ -1,5 +1,5 @@
 .hotkey {
-  opacity: 0.6;
+  opacity: 0.7;
   min-width: 14px;
   padding: 1px 6px;
   border: 1px solid hsl(var(--color-base-text) / 0.3);

--- a/src/styles/blocks/linked-article.css
+++ b/src/styles/blocks/linked-article.css
@@ -50,7 +50,7 @@
 
 .linked-article__hotkeys {
   margin-block-start: 6px;
-  opacity: 0.6;
+  opacity: 0.7;
   font-family: var(--font-family);
   font-size: var(--font-size-m);
   letter-spacing: 0;


### PR DESCRIPTION
Решила проблему в рамках #1066.

Обнаружила, что цвет в них задаётся не только с помощью цвета как у текста, но и благодаря `opacity`. Так что просто понизила прозрачность на 10%. В итоге получились цвета `#68696c` в светлой теме и `#bfc0c1` в тёмной.

Можно попробовать подобрать так цвет, который предлагала Света, но, кажется, на это уйдёт больше времени. А цвета, которые у меня получились, соответствуют минимальному уровню контрастности.

![Было и стало](https://github.com/doka-guide/platform/assets/17615202/b26bda6e-3a23-4323-a982-b30feddaa184)