### PR TITLE
Разбирается с ориентирами страницы материала

### DIFF
--- a/src/includes/blocks/linked-article.njk
+++ b/src/includes/blocks/linked-article.njk
@@ -1,8 +1,7 @@
 {% macro linkedArticle(article, type = 'previous') %}
   {% set icon = '←' if type === 'previous' else '→' %}
 
-  <aside class="linked-article linked-article--{{ type }}" style="--accent-color: var(--color-{{ article.section }})" aria-labelledby="article-{{ type }}">
-    <span class="visually-hidden" id="article-{{ type }}">{% if type === 'next' %}Следующий{% else %}Предыдущий{% endif %} материал</span>
+  <div class="linked-article linked-article--{{ type }}" style="--accent-color: var(--color-{{ article.section }})">
     <div class="linked-article__icon font-theme font-theme--code" aria-hidden="true">
       {{ icon }}
     </div>
@@ -14,5 +13,5 @@
         <kbd class="linked-article__hotkey hotkey">ctrl</kbd><span class="linked-article__hotkey hotkey linked-article__plus"> + </span><kbd class="linked-article__hotkey hotkey">alt</kbd><span class="linked-article__hotkey hotkey linked-article__plus"> + </span><kbd class="linked-article__hotkey hotkey">{{ icon }}</kbd>
       </div>
     </div>
-  </aside>
+  </div>
 {% endmacro %}

--- a/src/libs/heading-hierarchy/heading-hierarchy.js
+++ b/src/libs/heading-hierarchy/heading-hierarchy.js
@@ -89,9 +89,9 @@ function renderItem(item) {
 
 function render(rootItem) {
   return `
-    <div class="toc">
+    <aside class="toc" aria-label="Оглавление">
       ${renderItem(rootItem)}
-    </div>
+    </aside>
   `
 }
 

--- a/src/views/doc.njk
+++ b/src/views/doc.njk
@@ -17,7 +17,7 @@
 <div class="doc">
   <main class="doc__main">
     <article class="doc__article article {% if cover %}article--with-cover{% endif %}">
-      <header class="article__header">
+      <header class="article__header" aria-label="Материал">
         <div class="article__header-inner doc__wrapper">
           {% if cover %}
             {{ articleImage(class="article__image", cover=cover, authors=populatedCoverAuthors) }}
@@ -72,7 +72,7 @@
             <div class="article-nav__content"></div>
           </div>
 
-          <footer class="article__meta">
+          <footer class="article__meta" aria-label="Авторы и дата публикации">
             <div class="article__persons">
               {% include "contributors.njk" %}
             </div>

--- a/src/views/doc.njk
+++ b/src/views/doc.njk
@@ -108,8 +108,7 @@
             {% include "questions.njk" %}
           </div>
 
-          <aside class="doc__feedback-form" aria-labelledby="feedback">
-            <span class="visually-hidden" id="feedback">Оценка материала</span>
+          <aside class="doc__feedback-form" aria-label="Оценка материала">
             {% include "feedback-form.njk" %}
           </aside>
 
@@ -120,7 +119,7 @@
           {% endif %}
 
           {% if (previousArticle or nextArticle) %}
-            <div class="doc__linked-articles">
+            <aside class="doc__linked-articles" aria-label="Полезные материалы">
               {% if previousArticle %}
                 {{ linkedArticle(article=previousArticle, type="previous") }}
               {% endif %}
@@ -128,7 +127,7 @@
               {% if nextArticle %}
                 {{ linkedArticle(article=nextArticle, type="next") }}
               {% endif %}
-            </div>
+            </aside>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
Решаю задачу из #1153 и не только.

Что изменилось?

- Сделала оглавление ориентиром `complementary`.
- Объединила в один `<aside>` следующую и предыдущую статьи.
- Добавила подпись к ориентиру `banner` на странице материала.
- Добавила подпись к ориентиру `contentinfo` на странице материала.
- Все подписи добавила через `aria-label`.

Теперь в списке всех ориентиров на странице стало удобнее разобраться (на примере NVDA). Когда несколько одинаковых ориентиров на странице, бывает сложно понять, что в них содержится. Поэтому их рекомендуют подписывать в этом случае.

![Frame 18](https://github.com/doka-guide/platform/assets/17615202/efce34b6-3856-47a3-85d0-73315f800d9a)
