### PR TITLE
Добавляет отступы для блока с рекомендуемыми статьями

### DIFF
--- a/src/styles/blocks/doc.css
+++ b/src/styles/blocks/doc.css
@@ -82,7 +82,8 @@
 }
 
 @media not all and (min-width: 1024px) {
-  .doc__linked-articles {
+  .doc__linked-articles,
+  .doc__related-articles {
     padding-inline: inherit;
   }
 }


### PR DESCRIPTION
Небольшой пиар, который исправляет проблему со стилями из #1111.

Теперь на мобилках у блока с рекомендуемыми статьями есть отступы.

![Frame 18](https://github.com/doka-guide/platform/assets/17615202/cf50bd16-2ea9-4cdd-8efc-5d4ae1f92fdc)