### PR TITLE
Добавляет правильный шрифт для `<kbd>`

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -75,6 +75,12 @@
   margin-block-start: 5px;
 }
 
+.content > p > kbd,
+.content > ul > li > kbd,
+.content > ol > li > kbd {
+  font-family: var(--font-family, monospace);
+}
+
 .content > img,
 .content > video,
 .content > audio,

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -78,7 +78,7 @@
 .content > p > kbd,
 .content > ul > li > kbd,
 .content > ol > li > kbd {
-  font-family: var(--font-family, monospace);
+  font-family: 'Spot Mono', monospace;
 }
 
 .content > img,


### PR DESCRIPTION
Мне давно мазолит глаза то, что у нас для `<kbd>` используется шрифт по умолчанию. Вот поменяла.

![Frame 18](https://github.com/doka-guide/platform/assets/17615202/aacf0306-ef5c-4ae9-b17f-77af4600d333)

@skorobaeus, если хочешь ещё как-то дополнительно стилизовать тег, можешь смело добавлять стили сюда.