### PR TITLE
Улучшает кнопки для оценки материала

### DIFF
--- a/src/includes/feedback-form.njk
+++ b/src/includes/feedback-form.njk
@@ -42,7 +42,10 @@
     </ul>
     <div class="feedback-form__text" id="another-reason" hidden>
       <div class="text-control">
-        <textarea class="text-control__item text-control__input" name="answer" placeholder="Расскажите, пожалуйста, подробнее"></textarea>
+        <div class="text-control__row">
+          <textarea class="text-control__item text-control__input" name="answer" id="textarea" placeholder="Например, много ошибок"></textarea>
+          <label for="textarea">Другая причина</label>
+        </div> 
         <button class="text-control__item text-control__button button button--invert" type="submit">Отправить</button>
       </div>
     </div>

--- a/src/includes/feedback-form.njk
+++ b/src/includes/feedback-form.njk
@@ -1,11 +1,6 @@
-<form class="feedback-form" method="post" autocomplete="off" data-state="idle">
-  <div class="feedback-form__header font-theme font-theme--code">
-    <div class="feedback-form__title" data-state="idle">Статья была полезной?</div>
-    <div class="feedback-form__title feedback-form__title--success" data-state="success">Спасибо</div>
-    <div class="feedback-form__title feedback-form__title--error" data-state="error">Спасибо</div>
-  </div>
-
+<form class="feedback-form" method="post" autocomplete="off">
   <fieldset class="feedback-form__fieldset feedback-form__fieldset--vote font-theme font-theme--code">
+    <legend class="feedback-form__title font-theme font-theme--code">Статья была полезной?</legend>
     <button class="vote vote--up" name="answer" value="Понравилось" type="submit">
       <span class="visually-hidden">Понравилось</span>
       <span aria-hidden="true">^‿^</span>
@@ -57,7 +52,9 @@
     Если вы нашли ошибку, отправьте нам <a class="link" href="{{ constants.contentRepLink }}">пулреквест</a>!
   </p>
 
-  <p class="feedback-form__error" data-state="error">
-    Во время отправки формы что-то пошло не так. Попробуйте ещё раз?
+  <div role="status" class="feedback-form__success" id="success" data-state="success">Спасибо за оценку ❤️</div>
+
+  <p role="alert" class="feedback-form__error" id="error" data-state="error">
+    Во время отправки формы что-то пошло не так. Перезагрузите страницу и попробуйте оценить материал ещё раз.
   </p>
 </form>

--- a/src/includes/feedback-form.njk
+++ b/src/includes/feedback-form.njk
@@ -52,9 +52,9 @@
     Если вы нашли ошибку, отправьте нам <a class="link" href="{{ constants.contentRepLink }}">пулреквест</a>!
   </p>
 
-  <span role="status" class="feedback-form__success" id="success" data-state="success">Спасибо за оценку ❤️</span>
+  <p aria-live="polite" class="feedback-form__success" id="success" data-state="success">Спасибо за оценку ❤️</p>
 
-  <span role="alert" class="feedback-form__error" id="error" data-state="error">
+  <p aria-live="assertive" class="feedback-form__error" id="error" data-state="error">
     Во время отправки формы что-то пошло не так. Перезагрузите страницу и попробуйте оценить материал ещё раз.
-  </span>
+  </p>
 </form>

--- a/src/includes/feedback-form.njk
+++ b/src/includes/feedback-form.njk
@@ -5,13 +5,13 @@
       <span class="visually-hidden">Понравилось</span>
       <span aria-hidden="true">^‿^</span>
     </button>
-    <button class="vote vote--down" type="button">
+    <button class="vote vote--down" type="button" aria-expanded="false" aria-controls="reason">
       <span class="visually-hidden">Не понравилось</span>
       <span aria-hidden="true">ˇ⌒ˇ</span>
     </button>
   </fieldset>
 
-  <fieldset class="feedback-form__fieldset feedback-form__fieldset--reason" hidden>
+  <fieldset class="feedback-form__fieldset feedback-form__fieldset--reason" id="reason" hidden>
     <legend class="feedback-form__legend">Расскажите, что не понравилось?</legend>
     <ul class="feedback-control-list base-list">
       <li class="feedback-control-list__item">
@@ -35,12 +35,12 @@
         </button>
       </li>
       <li class="feedback-control-list__item">
-        <button class="feedback-form__reason-button button button--round" name="answer" value="Что-то другое" type="button">
+        <button class="feedback-form__reason-button button button--round button--another-reason" name="answer" value="Что-то другое" type="button" aria-expanded="false" aria-controls="another-reason">
           Что-то другое
         </button>
       </li>
     </ul>
-    <div class="feedback-form__text" hidden>
+    <div class="feedback-form__text" id="another-reason" hidden>
       <div class="text-control">
         <textarea class="text-control__item text-control__input" name="answer" placeholder="Расскажите, пожалуйста, подробнее"></textarea>
         <button class="text-control__item text-control__button button button--invert" type="submit">Отправить</button>

--- a/src/includes/feedback-form.njk
+++ b/src/includes/feedback-form.njk
@@ -52,9 +52,9 @@
     Если вы нашли ошибку, отправьте нам <a class="link" href="{{ constants.contentRepLink }}">пулреквест</a>!
   </p>
 
-  <div role="status" class="feedback-form__success" id="success" data-state="success">Спасибо за оценку ❤️</div>
+  <span role="status" class="feedback-form__success" id="success" data-state="success">Спасибо за оценку ❤️</span>
 
-  <p role="alert" class="feedback-form__error" id="error" data-state="error">
+  <span role="alert" class="feedback-form__error" id="error" data-state="error">
     Во время отправки формы что-то пошло не так. Перезагрузите страницу и попробуйте оценить материал ещё раз.
-  </p>
+  </span>
 </form>

--- a/src/scripts/modules/feedback-form.js
+++ b/src/scripts/modules/feedback-form.js
@@ -74,6 +74,7 @@ function init() {
 
   const voteDownButton = form.querySelector('.vote--down')
   const voteUpButton = form.querySelector('.vote--up')
+  const reasonButton = form.querySelector('.button--another-reason')
   const reasonFieldset = form.querySelector('.feedback-form__fieldset--reason')
   const textControl = form.querySelector('.feedback-form__text')
 
@@ -145,6 +146,7 @@ function init() {
   )
 
   voteButtonGroup.on(ButtonGroup.EVENTS.CORRECTION, () => {
+    voteDownButton.setAttribute('aria-expanded', 'true')
     reasonFieldset.hidden = false
   })
 
@@ -168,7 +170,7 @@ function init() {
 
   reasonsButtonGroup.on(ButtonGroup.EVENTS.CORRECTION, () => {
     textControl.hidden = false
-    detailedAnswer.focus()
+    reasonButton.setAttribute('aria-expanded', 'true')
   })
 
   form.addEventListener('submit', (event) => {

--- a/src/scripts/modules/feedback-form.js
+++ b/src/scripts/modules/feedback-form.js
@@ -63,10 +63,6 @@ class DetailedAnswer extends BaseComponent {
       })
     })
   }
-
-  focus() {
-    this.textarea.focus()
-  }
 }
 
 function init() {
@@ -126,7 +122,7 @@ function init() {
 
   detailedAnswer.on(DetailedAnswer.EVENTS.ANSWER, () => {
     setTimeout(() => {
-      reasonFieldset.disabled = true
+      reasonFieldset.inert = true
       voteUpButton.disabled = true
     })
   })
@@ -142,7 +138,7 @@ function init() {
     () => {
       setTimeout(() => {
         voteDownButton.disabled = true
-        reasonFieldset.disabled = true
+        reasonFieldset.inert = true
       })
     },
     { once: true }
@@ -162,7 +158,7 @@ function init() {
     ButtonGroup.EVENTS.ANSWER,
     () => {
       setTimeout(() => {
-        reasonFieldset.disabled = true
+        reasonFieldset.inert = true
         voteUpButton.disabled = true
         textControl.hidden = true
       })
@@ -197,9 +193,11 @@ function init() {
     })
       .then(() => {
         form.dataset.state = 'success'
+        form.dataset.ariaDescribedby = 'success'
       })
       .catch((error) => {
         form.dataset.state = 'error'
+        form.setAttribute('aria-describedby', 'error')
         console.error(error)
       })
       .finally(() => {

--- a/src/scripts/modules/feedback-form.js
+++ b/src/scripts/modules/feedback-form.js
@@ -193,7 +193,7 @@ function init() {
     })
       .then(() => {
         form.dataset.state = 'success'
-        form.dataset.ariaDescribedby = 'success'
+        form.setAttribute('aria-describedby', 'success')
       })
       .catch((error) => {
         form.dataset.state = 'error'

--- a/src/scripts/modules/feedback-form.js
+++ b/src/scripts/modules/feedback-form.js
@@ -77,6 +77,7 @@ function init() {
   const reasonButton = form.querySelector('.button--another-reason')
   const reasonFieldset = form.querySelector('.feedback-form__fieldset--reason')
   const textControl = form.querySelector('.feedback-form__text')
+  const textControlInput = form.querySelector('.text-control__input')
 
   let isSending = false
 
@@ -171,6 +172,7 @@ function init() {
   reasonsButtonGroup.on(ButtonGroup.EVENTS.CORRECTION, () => {
     textControl.hidden = false
     reasonButton.setAttribute('aria-expanded', 'true')
+    textControlInput.required = true
   })
 
   form.addEventListener('submit', (event) => {

--- a/src/styles/blocks/feedback-form.css
+++ b/src/styles/blocks/feedback-form.css
@@ -4,15 +4,13 @@
   line-height: var(--font-line-height-s);
 }
 
-.feedback-form__header {
+.feedback-form__title {
   margin-bottom: 0.4em;
   font-family: var(--font-family);
-  font-size: var(--font-size-l);
-  line-height: var(--font-line-height-l);
   letter-spacing: var(--letter-spacing);
+  font-size: var(--font-size-m);
+  line-height: var(--font-line-height-m);
 }
-
-.feedback-form__title {}
 
 .feedback-form__fieldset {
   margin: 0;
@@ -45,7 +43,7 @@
   border-radius: 6px;
 }
 
-.feedback-form__fieldset:disabled {
+.feedback-form__fieldset[inert] {
   opacity: 0.5;
 }
 
@@ -78,7 +76,6 @@
   color: hsl(0, 81%, 64%);
 }
 
-.feedback-form:not([data-state="idle"]) [data-state="idle"],
 .feedback-form:not([data-state="success"]) [data-state="success"],
 .feedback-form:not([data-state="error"]) [data-state="error"] {
   display: none;

--- a/src/styles/blocks/feedback-form.css
+++ b/src/styles/blocks/feedback-form.css
@@ -96,7 +96,7 @@
 @media (min-width: 1024px) {
   .feedback-form__reason-button {
     padding: 3px 19px;
-    line-height: calc(16 / 12);
+    line-height: calc(17 / 12);
   }
 }
 

--- a/src/styles/blocks/text-control.css
+++ b/src/styles/blocks/text-control.css
@@ -17,8 +17,6 @@
   --border-color-opacity: calc(1 - var(--is-dark-theme-on) * 0.6);
   flex: 1 1 auto;
   box-sizing: border-box;
-  padding-left: 0;
-  padding-right: 0;
   width: 100%;
   min-height: var(--input-height);
   height: var(--input-height);
@@ -40,6 +38,11 @@
 
 .text-control__button {
   flex: 0 0 auto;
+}
+
+.button--active:focus-visible,
+.text-control__button {
+  outline-offset: 3px;
 }
 
 @media not all and (min-width: 768px) {

--- a/src/styles/blocks/text-control.css
+++ b/src/styles/blocks/text-control.css
@@ -5,6 +5,12 @@
   gap: 20px;
 }
 
+.text-control__row {
+  width: 100%;
+  flex-grow: 1;
+  text-align: left;
+}
+
 .text-control__item {
   box-sizing: border-box;
   padding-block: var(--padding-block);

--- a/src/styles/blocks/text-control.css
+++ b/src/styles/blocks/text-control.css
@@ -41,7 +41,7 @@
 }
 
 .button--active:focus-visible,
-.text-control__button {
+.text-control__button:focus-visible {
   outline-offset: 3px;
 }
 

--- a/src/styles/blocks/vote.css
+++ b/src/styles/blocks/vote.css
@@ -43,5 +43,5 @@
 
 .vote--active {
   background-color: var(--vote-color);
-  color: hsl(0, 0%, 0%);
+  color: hsl(var(--color-black));
 }

--- a/src/styles/blocks/vote.css
+++ b/src/styles/blocks/vote.css
@@ -43,5 +43,5 @@
 
 .vote--active {
   background-color: var(--vote-color);
-  color: inherit;
+  color: hsl(0, 0%, 0%);
 }


### PR DESCRIPTION
Исправления в рамках #1067 и #1071.

Что изменилось:

- перенесла «Спасибо» из заголовка под поле с оценкой, заменила текст на «Спасибо за оценку ❤️»;
- изменила текст ошибки с «Во время отправки формы что-то пошло не так. Попробуйте ещё раз?» на «Во время отправки формы что-то пошло не так. Перезагрузите страницу и попробуйте оценить материал ещё раз»;
- теперь заголовок групп кнопок постоянно «Статья была полезной?», сделала его `<legend>`;
- связала статус об успешной отправке и ошибку с `<form>` с помощью `aria-describedby` и live region;
- навесила на `<fieldset>` атрибут `inert` вместо `disabled` (`disabled` нельзя задавать группам элементов, только одному интерактивному);
- убрала автоматический перенос фокуса на текстовое поле (так не очень хорошо делать в формах);
- добавила лейбл к полю с другой причиной;
- сделала поле с другой причиной `required`;
- добавила состояние `aria-expanded` для кнопок, раскрывающих блоки;
- слегка увеличила высоту кнопок с причиной, чтобы они были больше 23px.

Почему так решила описала уже в ишьюз (кроме `inert` и заголовка). Кажется, что логичнее и удобнее, чтобы этот заголовок относился к двум кнопкам, а не ко всей форме. Тем более это хорошая практика, чтобы у `<fieldset>` был заголовок.

Что касается текста ошибки, то он какой-то непонятный. Почему возникла ошибка? Как её исправить? Что вообще делать? Попробовала исправить эту непоредёленность предложением про перезагрузку страницы.

<s>Единственный вопрос остался к @skorobaeus.</s>

<s>Нетекстовый контраст кнопок для оценок в статьях (`#F499AF`, `#51e957`) на белом фоне (`#ffffff`) в светлой теме соотносятся 1.59:1 и не соответствуют минимальному соотношению 3:1.</s>

![Было и стало](https://github.com/doka-guide/platform/assets/17615202/b20bfe5a-642d-44ac-810d-a9cbf2901927)
