### PR TITLE
Улучшает блок с Baseline

### DIFF
--- a/src/includes/blocks/baseline.njk
+++ b/src/includes/blocks/baseline.njk
@@ -1,29 +1,29 @@
 <div class="wdi-browser-compat">
-  <span class="wdi-browser-compat__label">Поддержка в браузерах</span>
+  <span class="wdi-browser-compat__label">Поддержка в браузерах:</span>
   <ul class="wdi-browser-compat__items">
     {% for browser in baseline.keys %}
       <li class="wdi-browser-compat__item">
         <span class="wdi-browser-compat__icon" data-browser="{{ browser }}">
           {% if baseline.supported[browser] %}
-              <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, Поддерживается</span>
+              <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, поддерживается</span>
             </span>
-            <span aria-label="Поддерживается" title="Поддерживается" class="wdi-browser-compat__version" data-compat="yes">{{ baseline.versions[browser] }}</span>
+            <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="yes">{{ baseline.versions[browser] }}</span>
           {% elif baseline.flagged[browser] %}
             <span class="wdi-browser-compat__icon" data-browser="firefox">
-              <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, За флагом</span>
+              <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, за флагом</span>
             </span>
-            <span aria-label="За флагом" title="За флагом" class="wdi-browser-compat__version" data-compat="flag">
+            <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="flag">
             </span>
           {% elif baseline.preview[browser] %}
             <span class="wdi-browser-compat__icon" data-browser="safari">
-              <span class="visually-hidden">{{ baseline.names[browser] }}, Превью</span>
+              <span class="visually-hidden">{{ baseline.names[browser] }}, превью</span>
             </span>
-            <span aria-label="Превью" title="Превью"> class="wdi-browser-compat__version" data-compat="preview"</span>
+            <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="preview"></span>
           {% else %}
             <span class="wdi-browser-compat__icon" data-browser="edge">
-              <span class="visually-hidden">{{ baseline.names[browser] }}, Не поддерживается</span>
+              <span class="visually-hidden">{{ baseline.names[browser] }}, не поддерживается</span>
             </span>
-            <span aria-label="Не поддерживается" title="Не поддерживается" class="wdi-browser-compat__version" data-compat="no"></span>
+            <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="no"></span>
           {% endif %}
       </li>
     {% endfor %}

--- a/src/styles/blocks/baseline.css
+++ b/src/styles/blocks/baseline.css
@@ -1,23 +1,18 @@
 .wdi-browser-compat {
   max-width: 87.5%;
+  margin-block-start: 40px;
   align-items: center;
-  color: var(--wdi-text-color, #585b63);
+  color: var(--color-light);
   display: flex;
   flex-wrap: wrap;
 }
 
-.wdi-browser-compat__label {
-  color: var(--wdi-text-color, #585b63);
-  flex: 0 0 100%;
-  font-style: normal;
-  margin-right: 1rem;
-  width: 100%;
-}
-
 .wdi-browser-compat__items {
   display: flex;
-  margin: 1rem 1rem 1rem 0;
+  flex-wrap: wrap;
+  margin: 1rem 0;
   padding: 0;
+  gap: 24px;
   list-style: none;
 }
 
@@ -30,7 +25,6 @@
 .wdi-browser-compat__icon {
   display: inline-block;
   height: 24px;
-  margin-left: 24px;
   margin-right: 6px;
   width: 24px;
   background-repeat: no-repeat no-repeat;
@@ -112,5 +106,11 @@
   .wdi-browser-compat__link {
     flex: none;
     margin-left: auto;
+  }
+}
+
+@media (min-width: 600px) {
+  .wdi-browser-compat__label {
+    margin-right: 24px;
   }
 }


### PR DESCRIPTION
По мотивам ишью #1143. Смотреть можно в [доке про `grid-area`](https://platform-1187.dev.doka.guide/css/grid-area/).

Что исправила:

- убрала лишние ARIA-атрибуты и `title` из `<span>`, скрыла повторяющуюся инфу от скринридеров;
- слегка изменила скрытый текст (убрала заглавную букву, так как это всё одно предложение);
- вернула классы на место в одном `<span>`;
- использовала наш цвет для текста и пофиксила проблемы с контрастностью;
- слегка изменила способ задавания отступов, пофиксила лишний на мобилках и планшетах;
- добавила отступ ко всему блоку.

<s>Остался только один вопрос: в итоге мы планируем делать «Поддержка в браузерах» заголовком или нет? Если да, нужна ваша помощь, чтобы заголовок не попадал в оглавление статьи.</s>

![Frame 1](https://github.com/doka-guide/platform/assets/17615202/f6f5ab25-d93a-40a9-b8fc-8fdb48ba841c)