### PR TITLE
Улучшает форму подписки на рассылку

### DIFF
--- a/src/scripts/modules/subscribe-form.js
+++ b/src/scripts/modules/subscribe-form.js
@@ -108,16 +108,19 @@ class Settings extends BaseComponent {
   progress() {
     this.clearStatus()
     this.status.classList.toggle('progress')
+    this.status.setAttribute('aria-describedby', 'subscribe-progress')
   }
 
   success() {
     this.clearStatus()
     this.status.classList.toggle('success')
+    this.status.setAttribute('aria-describedby', 'subscribe-success')
   }
 
   error() {
     this.clearStatus()
     this.status.classList.toggle('error')
+    this.status.setAttribute('aria-describedby', 'subscribe-error')
   }
 
   focus() {
@@ -172,16 +175,19 @@ class Unsubscribe extends BaseComponent {
   progress() {
     this.clearStatus()
     this.status.classList.toggle('progress')
+    this.status.setAttribute('aria-describedby', 'usubscribe-progress')
   }
 
   success() {
     this.clearStatus()
     this.status.classList.toggle('success')
+    this.status.setAttribute('aria-describedby', 'usubscribe-success')
   }
 
   error() {
     this.clearStatus()
     this.status.classList.toggle('error')
+    this.status.setAttribute('aria-describedby', 'usubscribe-error')
   }
 
   focus() {

--- a/src/scripts/modules/subscribe-form.js
+++ b/src/scripts/modules/subscribe-form.js
@@ -284,7 +284,6 @@ async function init() {
   })
 
   settingsForm.addEventListener('submit', (event) => {
-    console.log('!!!!')
     event.preventDefault()
 
     if (isSending) {
@@ -292,18 +291,6 @@ async function init() {
     }
 
     const formData = prepareFormData(settingsForm)
-
-    // if (!Settings.VALIDATION_REGEXP.test(this.email.value.trim())) {
-    //   settings.errorInvalidField()
-    //   console.log('Invalid email')
-    //   return
-    // }
-
-    // if (this.email.value === '') {
-    //   this.errorEmptyField()
-    //   console.log('Empty email')
-    //   return
-    // }
 
     const email = formData.email
     if (email) {
@@ -321,8 +308,6 @@ async function init() {
       })
       .catch((error) => {
         settings.error()
-        settings.errorEmptyField()
-        settings.errorInvalidField()
         console.error(error)
       })
       .finally(() => {

--- a/src/scripts/modules/subscribe-form.js
+++ b/src/scripts/modules/subscribe-form.js
@@ -7,10 +7,6 @@ class Settings extends BaseComponent {
     }
   }
 
-  static get VALIDATION_REGEXP() {
-    return /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-  }
-
   constructor({
     rootElement,
     title,
@@ -85,18 +81,6 @@ class Settings extends BaseComponent {
         })
       }
     }
-
-    this.button.addEventListener('click', () => {
-      const text = this.email.value.trim()
-      if (Settings.VALIDATION_REGEXP.test(text)) {
-        this.emit(Settings.EVENTS.EMAIL, text)
-      }
-    })
-    ;['keydown', 'keyup'].forEach((eventType) => {
-      this.email.addEventListener(eventType, (event) => {
-        event.stopPropagation()
-      })
-    })
   }
 
   clearStatus() {
@@ -121,14 +105,6 @@ class Settings extends BaseComponent {
     this.clearStatus()
     this.status.classList.toggle('error')
     this.status.setAttribute('aria-describedby', 'subscribe-error')
-  }
-
-  focus() {
-    if (this.email.value === '') {
-      this.email.focus()
-    } else {
-      this.who.focus()
-    }
   }
 }
 
@@ -308,6 +284,7 @@ async function init() {
   })
 
   settingsForm.addEventListener('submit', (event) => {
+    console.log('!!!!')
     event.preventDefault()
 
     if (isSending) {
@@ -315,6 +292,18 @@ async function init() {
     }
 
     const formData = prepareFormData(settingsForm)
+
+    // if (!Settings.VALIDATION_REGEXP.test(this.email.value.trim())) {
+    //   settings.errorInvalidField()
+    //   console.log('Invalid email')
+    //   return
+    // }
+
+    // if (this.email.value === '') {
+    //   this.errorEmptyField()
+    //   console.log('Empty email')
+    //   return
+    // }
 
     const email = formData.email
     if (email) {
@@ -332,6 +321,8 @@ async function init() {
       })
       .catch((error) => {
         settings.error()
+        settings.errorEmptyField()
+        settings.errorInvalidField()
         console.error(error)
       })
       .finally(() => {

--- a/src/scripts/modules/subscribe-form.js
+++ b/src/scripts/modules/subscribe-form.js
@@ -92,6 +92,11 @@ class Settings extends BaseComponent {
   progress() {
     this.clearStatus()
     this.status.classList.toggle('progress')
+    this.email.disabled = true
+    this.button.disabled = true
+    this.who.disabled = true
+    this.grade.disabled = true
+    this.interests.disabled = true
     this.status.setAttribute('aria-describedby', 'subscribe-progress')
   }
 
@@ -151,6 +156,8 @@ class Unsubscribe extends BaseComponent {
   progress() {
     this.clearStatus()
     this.status.classList.toggle('progress')
+    this.button.disabled = true
+    this.input.disabled = true
     this.status.setAttribute('aria-describedby', 'usubscribe-progress')
   }
 
@@ -164,10 +171,6 @@ class Unsubscribe extends BaseComponent {
     this.clearStatus()
     this.status.classList.toggle('error')
     this.status.setAttribute('aria-describedby', 'usubscribe-error')
-  }
-
-  focus() {
-    this.input.focus()
   }
 }
 

--- a/src/scripts/modules/subscribe-form.js
+++ b/src/scripts/modules/subscribe-form.js
@@ -92,11 +92,6 @@ class Settings extends BaseComponent {
   progress() {
     this.clearStatus()
     this.status.classList.toggle('progress')
-    this.email.disabled = true
-    this.button.disabled = true
-    this.who.disabled = true
-    this.grade.disabled = true
-    this.interests.disabled = true
     this.status.setAttribute('aria-describedby', 'subscribe-progress')
   }
 
@@ -156,8 +151,6 @@ class Unsubscribe extends BaseComponent {
   progress() {
     this.clearStatus()
     this.status.classList.toggle('progress')
-    this.button.disabled = true
-    this.input.disabled = true
     this.status.setAttribute('aria-describedby', 'usubscribe-progress')
   }
 

--- a/src/styles/blocks/subscribe-page.css
+++ b/src/styles/blocks/subscribe-page.css
@@ -156,22 +156,19 @@
 /* Стили для текстов статусов */
 .error-text,
 .success-text,
-.progress-text,
-.error-email-text {
+.progress-text {
   display: none;
   padding-top: 15px;
   font-size: 0.8em;
 }
 
-.error-text,
-.error-email-text {
+.error-text {
   color: hsl(0, 81%, 64%);
 }
 
 .progress .progress-text,
 .success .success-text,
-.error .error-text,
-.error-email .error-email-text {
+.error .error-text {
   display: block;
 }
 

--- a/src/styles/blocks/subscribe-page.css
+++ b/src/styles/blocks/subscribe-page.css
@@ -113,7 +113,7 @@
   gap: 20px;
 }
 
-.unsubscribe__label {
+.unsubscribe__field {
   flex-grow: 1;
 }
 

--- a/src/styles/blocks/subscribe-page.css
+++ b/src/styles/blocks/subscribe-page.css
@@ -148,9 +148,15 @@
 
 .progress .text-control__button::after {
   content: "";
-  border: 2px dashed white;
+  border: 2px dashed hsl(var(--color-dark));
   border-radius: 50%;
   animation: progress-wheel 6s infinite linear;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress .text-control__button::after {
+    animation: none;
+  }
 }
 
 /* Стили для текстов статусов */

--- a/src/styles/blocks/subscribe-page.css
+++ b/src/styles/blocks/subscribe-page.css
@@ -37,10 +37,24 @@
   margin-block-start: 1em;
 }
 
+.subscribe-settings__title {
+  --font-size: var(--font-size-headline-2);
+  --line-height: var(--font-line-height-headline-2);
+  margin-top: 0;
+  margin-block-end: 0;
+  display: inline;
+  font: inherit;
+  font-size: var(--font-size);
+  line-height: var(--line-height);
+}
+
 .subscribe-settings__label {
+  --font-size: var(--font-size-headline-3);
+  --line-height: var(--font-line-height-headline-3);
   display: block;
   margin-block-end: 30px;
-  font-size: 36px;
+  font-size: var(--font-size);
+  line-height: var(--line-height);
 }
 
 .subscribe-settings__input,
@@ -73,6 +87,7 @@
 }
 
 .subscribe-settings__control-label {
+  display: inline-flex;
   font-size: inherit;
 }
 
@@ -89,9 +104,7 @@
 /* Стили для формы отписки */
 .unsubscribe-section {
   display: grid;
-  gap: var(--gap);
   margin-block-start: calc(var(--gap) * 2);
-  padding: var(--gap);
   background-color: var(--color-fade);
 }
 
@@ -136,6 +149,10 @@
   block-size: 30px;
 }
 
+.subscribe__status {
+  margin-block-start: var(--gap);
+}
+
 /* Класс на время обработки */
 .form-with-status.progress {
   opacity: 0.5;
@@ -164,7 +181,7 @@
 .success-text,
 .progress-text {
   display: none;
-  padding-top: 15px;
+  padding: 0;
   font-size: 0.8em;
 }
 
@@ -205,11 +222,6 @@
     font-size: 16px;
   }
 
-  .subscribe-settings__label {
-    font-size: 24px;
-    margin-block-end: 15px;
-  }
-
   .subscribe-settings__fieldset {
     gap: 8px;
   }
@@ -219,6 +231,7 @@
     inline-size: 20px;
     height: 20px;
     block-size: 20px;
+    margin-inline-end: 8px;
   }
 
   .unsubscribe__form {

--- a/src/styles/blocks/subscribe-page.css
+++ b/src/styles/blocks/subscribe-page.css
@@ -96,6 +96,10 @@
   transition: color 0.2s ease-out;
 }
 
+.subscribe-settings__button:focus-visible {
+  outline-offset: 3px;
+}
+
 .form-with-status .text-control__button::after {
   content: "";
   position: absolute;
@@ -148,9 +152,31 @@
 
 .progress .form-with-status__status,
 .success .form-with-status__status,
-.error .form-with-status__status {
+.error .form-with-status__status,
+.error-email .form-with-status__status {
   visibility: visible;
   opacity: 1;
+}
+
+.error-text,
+.success-text,
+.progress-text,
+.error-email-text {
+  display: none;
+  padding-top: 15px;
+  font-size: 0.8em;
+}
+
+.error-text,
+.error-email-text {
+  color: hsl(0, 81%, 64%);
+}
+
+.progress .progress-text,
+.success .success-text,
+.error .error-text,
+.error-email .error-email-text {
+  display: block;
 }
 
 .unsubscribe-section {
@@ -167,15 +193,16 @@
 
 .unsubscribe__form {
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   align-items: start;
-  gap: 20px;
 }
 
 .unsubscribe__row {
-  width: 20%;
-  inline-size: 20%;
-  text-align: center;
+  display: flex;
+  align-items: start;
+  width: 100%;
+  gap: 20px;
 }
 
 .unsubscribe__label {
@@ -214,6 +241,7 @@
   .unsubscribe__row {
     width: 100%;
     inline-size: 100%;
+    flex-wrap: wrap;
   }
 }
 

--- a/src/styles/blocks/subscribe-page.css
+++ b/src/styles/blocks/subscribe-page.css
@@ -2,6 +2,7 @@
   --gap: 50px;
 }
 
+/* Стили для формы подписки */
 .subscribe-settings {
   display: grid;
   gap: var(--gap);
@@ -11,26 +12,11 @@
   background-color: var(--color-fade);
 }
 
-/* Отдельный класс для форм со статусами состояния */
-.form-with-status {
-  transition: opacity 0.2s ease-in-out;
-}
-
-/* Класс на время обработки */
-.form-with-status.progress {
-  opacity: 0.5;
-  pointer-events: none;
-}
-
-/* Класс на случай успеха — progress */
-
-/* Класс на случай провала — error */
-
 .subscribe-settings__row--hidden {
   display: none;
 }
 
-.subscribe-settings__row:has(.subscribe-settings__button) {
+.subscribe-settings__row--center {
   text-align: center;
 }
 
@@ -100,85 +86,7 @@
   outline-offset: 3px;
 }
 
-.form-with-status .text-control__button::after {
-  content: "";
-  position: absolute;
-  inset: 50%;
-  translate: -50% -50%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 30px;
-  inline-size: 30px;
-  height: 30px;
-  block-size: 30px;
-}
-
-.progress .text-control__button {
-  color: currentColor;
-}
-
-.progress .text-control__button::after {
-  content: "";
-  border: 2px dashed white;
-  border-radius: 50%;
-  animation: progress-wheel 6s infinite linear;
-}
-
-.success .text-control__button {
-  color: currentColor;
-}
-
-.success .text-control__button::after {
-  content: "✅";
-}
-
-.error .text-control__button {
-  color: currentColor;
-}
-
-.error .text-control__button::after {
-  content: "❌";
-}
-
-.form-with-status__status {
-  display: block;
-  margin-block: 0.5em;
-  font-size: 0.8em;
-  visibility: hidden;
-  opacity: 0;
-  transition: opacity 0.2s ease-in;
-}
-
-.progress .form-with-status__status,
-.success .form-with-status__status,
-.error .form-with-status__status,
-.error-email .form-with-status__status {
-  visibility: visible;
-  opacity: 1;
-}
-
-.error-text,
-.success-text,
-.progress-text,
-.error-email-text {
-  display: none;
-  padding-top: 15px;
-  font-size: 0.8em;
-}
-
-.error-text,
-.error-email-text {
-  color: hsl(0, 81%, 64%);
-}
-
-.progress .progress-text,
-.success .success-text,
-.error .error-text,
-.error-email .error-email-text {
-  display: block;
-}
-
+/* Стили для формы отписки */
 .unsubscribe-section {
   display: grid;
   gap: var(--gap);
@@ -207,6 +115,82 @@
 
 .unsubscribe__label {
   flex-grow: 1;
+}
+
+/* Отдельный класс для форм со статусами состояния */
+.form-with-status {
+  transition: opacity 0.2s ease-in-out;
+}
+
+.form-with-status .text-control__button::after {
+  content: "";
+  position: absolute;
+  inset: 50%;
+  translate: -50% -50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 30px;
+  inline-size: 30px;
+  height: 30px;
+  block-size: 30px;
+}
+
+/* Класс на время обработки */
+.form-with-status.progress {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.progress .text-control__button {
+  color: currentColor;
+}
+
+.progress .text-control__button::after {
+  content: "";
+  border: 2px dashed white;
+  border-radius: 50%;
+  animation: progress-wheel 6s infinite linear;
+}
+
+/* Стили для текстов статусов */
+.error-text,
+.success-text,
+.progress-text,
+.error-email-text {
+  display: none;
+  padding-top: 15px;
+  font-size: 0.8em;
+}
+
+.error-text,
+.error-email-text {
+  color: hsl(0, 81%, 64%);
+}
+
+.progress .progress-text,
+.success .success-text,
+.error .error-text,
+.error-email .error-email-text {
+  display: block;
+}
+
+/* Класс на случай успеха — progress */
+.success .text-control__button {
+  color: currentColor;
+}
+
+.success .text-control__button::after {
+  content: "✅";
+}
+
+/* Класс на случай провала — error */
+.error .text-control__button {
+  color: currentColor;
+}
+
+.error .text-control__button::after {
+  content: "❌";
 }
 
 @media (max-width: 768px) {

--- a/src/transforms/headings-anchor-transform.js
+++ b/src/transforms/headings-anchor-transform.js
@@ -17,8 +17,9 @@ function createButtonMarkup(id, headingText) {
 
 module.exports = function (window) {
   const content = window.document.querySelector('.content')
+  const subscription = window.document.querySelector('.subscribe-page')
 
-  if (content) {
+  if (content && !subscription) {
     let headings = content.querySelectorAll(
       'h2, h3, h4, h5, h6, #questions > div.questions__list > div.question__request > aside > div > p:first-of-type'
     )

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -19,13 +19,11 @@
     <p>Здесь можете подписаться и сразу рассказать немного о себе, чтобы мы настроили рассылку под ваши интересы.</p>
 
     <form class="subscribe-page__subscribe subscribe-settings form-with-status" action="">
+      <p class="subscribe-settings__label">Настроить рассылку</p>
       <div class="subscribe-settings__row">
-        <label class="subscribe-settings__label" for="email">
-          Нам обязательно нужна ваша почта *
-        </label>
         <input type="hidden" name="active" value="false">
         <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" inputmode="email" autocomplete="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
-        <span class="subscribe-settings__hint">Ваш e-mail</span>
+        <label for="email" class="subscribe-settings__hint">Ваш e-mail (обязательно)</label>
       </div>
       <div class="subscribe-settings__row">
         <fieldset class="subscribe-settings__fieldset">
@@ -48,15 +46,15 @@
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="radio" name="who" value="qa" id="tester">
-            QA
+            qa
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="radio" name="who" value="devops" id="devoops">
-            DevOps
+            девопс
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="radio" name="who" value="devrel" id="architect">
-            DevRel
+            деврел
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="radio" name="who" value="teamlead" id="lead">
@@ -76,11 +74,11 @@
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="radio" name="who" value="data" id="datascience">
-            Data Science и ML
+            data science и машинное обучение
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="radio" name="who" value="hr" id="hiremanager">
-            HR
+            эйчар
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="radio" name="who" value="not-it" id="notit">
@@ -148,10 +146,10 @@
       <p>Здесь можно отписаться от рассылки <span aria-hidden="true">U×ᴥ×U</span></p>
       <form class="subscribe-page__unsubscribe unsubscribe__form form-with-status" action="">
         <div class="unsubscribe__row">
-          <label class="unsubscribe__label">
-            <input type="text" name="reason" class="unsubscribe__input subscribe-settings__input" placeholder="Например, слишком часто приходят письма">
-            <span class="unsubscribe__hint subscribe-settings__hint">Расскажите, что не понравилось?</span>
-          </label>
+          <div class="unsubscribe__field">
+            <input type="text" name="reason" id="reason" class="unsubscribe__input subscribe-settings__input" placeholder="Например, слишком часто приходят письма">
+            <label for="reason" class="unsubscribe__hint subscribe-settings__hint">Расскажите, что не понравилось?</label>
+          </div>
           <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Отписаться</button>
         </div>
         {# Ниже меняем сообщения под статус #}

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -31,27 +31,27 @@
         <fieldset class="subscribe-settings__fieldset">
           <legend class="subscribe-settings__label">Как вы связаны с веб-разработкой?</legend>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="front" id="noob">
+            <input class="subscribe-settings__control" type="radio" name="who" value="front" id="frontenddev">
             фронтенд-разработчик
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="back" id="cross">
+            <input class="subscribe-settings__control" type="radio" name="who" value="back" id="backenddev">
             бэкенд-разработчик
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="full" id="junior">
+            <input class="subscribe-settings__control" type="radio" name="who" value="full" id="fullstack">
             фуллстек-разработчик
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="designer" id="middle">
+            <input class="subscribe-settings__control" type="radio" name="who" value="designer" id="artist">
             дизайнер
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="qa" id="sinior">
+            <input class="subscribe-settings__control" type="radio" name="who" value="qa" id="tester">
             QA
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="devops" id="teamlead">
+            <input class="subscribe-settings__control" type="radio" name="who" value="devops" id="devoops">
             DevOps
           </label>
           <label class="subscribe-settings__control-label">
@@ -59,35 +59,35 @@
             DevRel
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="teamlead" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="teamlead" id="lead">
             тимлид
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="manager" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="manager" id="project">
             менеджер продукта или проектов
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="engineer" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="engineer" id="engmanager">
             engineering manager
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="analysis" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="analysis" id="analytics">
             аналитик
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="data" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="data" id="datascience">
             Data Science и ML
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="hr" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="hr" id="hiremanager">
             HR
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="not-it" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="not-it" id="notit">
             я не из IT
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="who" value="sometingelse" id="nobody">
+            <input class="subscribe-settings__control" type="radio" name="who" value="sometingelse" id="another">
             совсем другое
           </label>
         </fieldset>
@@ -96,27 +96,27 @@
         <fieldset class="subscribe-settings__fieldset">
           <legend class="subscribe-settings__label">Ваш грейд</legend>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="grade" value="student" id="noob">
+            <input class="subscribe-settings__control" type="radio" name="grade" value="student" id="start">
             только учусь
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="grade" value="intern" id="cross">
+            <input class="subscribe-settings__control" type="radio" name="grade" value="intern" id="firstlvl">
             стажёр
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="grade" value="junior" id="cross">
+            <input class="subscribe-settings__control" type="radio" name="grade" value="junior" id="secondlvl">
             начинающий специалист
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="grade" value="middle" id="cross">
+            <input class="subscribe-settings__control" type="radio" name="grade" value="middle" id="thirdlvl">
             специалист
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="grade" value="senior" id="cross">
+            <input class="subscribe-settings__control" type="radio" name="grade" value="senior" id="fourthlvl">
             опытный специалист
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="radio" name="grade" value="master" id="cross">
+            <input class="subscribe-settings__control" type="radio" name="grade" value="master" id="fithlvl">
             высший пилотаж
           </label>
         </fieldset>
@@ -125,11 +125,11 @@
         <fieldset class="subscribe-settings__fieldset">
           <legend class="subscribe-settings__label">Мне интересно читать:</legend>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="checkbox" name="interest" value="digest" id="interests" checked>
+            <input class="subscribe-settings__control" type="checkbox" name="interest" value="digest" id="base" checked>
             Дайджест Доки (один раз в месяц)
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="checkbox" name="interest" value="dream-job" id="interests" checked>
+            <input class="subscribe-settings__control" type="checkbox" name="interest" value="dream-job" id="special" checked>
             Спецпроект Доки «<a href="https://dream-job.doka.guide">Трудоустройство</a>» (по мере выхода глав)
           </label>
         </fieldset>

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -18,13 +18,13 @@
     <p>Дока — это гид по веб-платформе. В справочнике можете найти ответы на повседневные вопросы, а в рассылках мы собираем тематические подборки, советы от экспертов, авторские и партнёрские колонки.</p>
     <p>Здесь можете подписаться и сразу рассказать немного о себе, чтобы мы настроили рассылку под ваши интересы.</p>
 
-    <form class="subscribe-page__subscribe subscribe-settings form-with-status" autocomplete="email" action="">
+    <form class="subscribe-page__subscribe subscribe-settings form-with-status" action="">
       <div class="subscribe-settings__row">
         <label class="subscribe-settings__label" for="email">
           Нам обязательно нужна ваша почта
         </label>
         <input type="hidden" name="active" value="false">
-        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
+        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" autocomplete="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
         <span class="subscribe-settings__hint">Ваш e-mail</span>
       </div>
       <div class="subscribe-settings__row">

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -138,9 +138,9 @@
       <div class="subscribe-settings__row subscribe-settings__row--center">
         <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Подписаться</button>
         {# Ниже меняем сообщения под статус #}
-        <span role="status" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</span>
-        <span role="status" class="success-text" id="subscribe-success">Вы подписались на рассылку, ура 🎉</span>
-        <span role="alert" class="error-text" data-state="error" id="subscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте подписаться ещё раз.</span>
+        <p aria-live="polite" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</p>
+        <p aria-live="polite" class="success-text" id="subscribe-success">Вы подписались на рассылку, ура 🎉</p>
+        <p aria-live="assertive" class="error-text" data-state="error" id="subscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте подписаться ещё раз.</p>
       </div>
     </form>
 
@@ -156,9 +156,9 @@
         </div>
         {# Ниже меняем сообщения под статус #}
         <div class="unsubscribe__status">
-          <span role="status" class="progress-text" id="usubscribe-progress">Отписываем от рассылки ⌛</span>
-          <span role="status" class="success-text" id="usubscribe-success">Вы отписались от рассылки ☹️</span>
-          <span role="alert" class="error-text" data-state="error" id="usubscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте отписаться ещё раз.</span>
+          <p aria-live="polite" class="progress-text" id="usubscribe-progress">Отписываем от рассылки ⌛</p>
+          <p aria-live="polite" class="success-text" id="usubscribe-success">Вы отписались от рассылки ☹️</p>
+          <p aria-live="assertive" class="error-text" data-state="error" id="usubscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте отписаться ещё раз.</p>
         </div>
       </form>
     </section>

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -18,7 +18,7 @@
     <p>Дока — это гид по веб-платформе. В справочнике можете найти ответы на повседневные вопросы, а в рассылках мы собираем тематические подборки, советы от экспертов, авторские и партнёрские колонки.</p>
     <p>Здесь можете подписаться и сразу рассказать немного о себе, чтобы мы настроили рассылку под ваши интересы.</p>
 
-    <form class="subscribe-page__subscribe subscribe-settings form-with-status" autocomplete="on" action="">
+    <form class="subscribe-page__subscribe subscribe-settings form-with-status" autocomplete="email" action="">
       <div class="subscribe-settings__row">
         <label class="subscribe-settings__label" for="email">
           Нам обязательно нужна ваша почта

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -150,7 +150,7 @@
         <div class="unsubscribe__row">
           <label class="unsubscribe__label">
             <input type="text" name="reason" class="unsubscribe__input subscribe-settings__input" placeholder="Например, слишком часто приходят письма">
-            <span class="unsubscribe__hint subscribe-settings__hint">Расскажете, что не понравилось?</span>
+            <span class="unsubscribe__hint subscribe-settings__hint">Расскажите, что не понравилось?</span>
           </label>
           <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Отписаться</button>
         </div>

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -21,7 +21,7 @@
     <form class="subscribe-page__subscribe subscribe-settings form-with-status" action="">
       <div class="subscribe-settings__row">
         <label class="subscribe-settings__label" for="email">
-          Нам обязательно нужна ваша почта
+          Нам обязательно нужна ваша почта *
         </label>
         <input type="hidden" name="active" value="false">
         <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" autocomplete="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -24,7 +24,7 @@
           Нам обязательно нужна ваша почта *
         </label>
         <input type="hidden" name="active" value="false">
-        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" autocomplete="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
+        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" inputmode="email" autocomplete="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
         <span class="subscribe-settings__hint">Ваш e-mail</span>
       </div>
       <div class="subscribe-settings__row">

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -24,7 +24,7 @@
           Нам обязательно нужна ваша почта
         </label>
         <input type="hidden" name="active" value="false">
-        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" aria-invalid="false" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
+        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
         <span class="subscribe-settings__hint">Ваш e-mail</span>
       </div>
       <div class="subscribe-settings__row">

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -15,17 +15,18 @@
     </div>
   </div>
   <div class="standalone-page__content standalone-page__wrapper content">
-    <p>Дока — это гид по веб-платформе. В справочнике вы можете найти ответы на повседневные вопросы, а в рассылках мы собираем тематические подборки, советы от экспертов, авторские и партнёрские колонки.</p>
-    <p>Здесь вы можете подписаться и сразу рассказать немного о себе, чтобы мы настроили рассылку под ваши интересы.</p>
+    <p>Дока — это гид по веб-платформе. В справочнике можете найти ответы на повседневные вопросы, а в рассылках мы собираем тематические подборки, советы от экспертов, авторские и партнёрские колонки.</p>
+    <p>Здесь можете подписаться и сразу рассказать немного о себе, чтобы мы настроили рассылку под ваши интересы.</p>
 
-    <form class="subscribe-page__subscribe subscribe-settings form-with-status" action="">
+    <form class="subscribe-page__subscribe subscribe-settings form-with-status" autocomplete="on" action="">
       <div class="subscribe-settings__row">
         <label class="subscribe-settings__label" for="email">
           Нам обязательно нужна ваша почта
         </label>
         <input type="hidden" name="active" value="false">
-        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email">
+        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" aria-invalid="false" required>
         <span class="subscribe-settings__hint">Ваш e-mail</span>
+        <p class="error-email-text" id="empty-field">Пожалуйста, введите почту 🐶</p>
       </div>
       <div class="subscribe-settings__row">
         <fieldset class="subscribe-settings__fieldset">
@@ -126,7 +127,7 @@
           <legend class="subscribe-settings__label">Мне интересно читать:</legend>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="checkbox" name="interest" value="digest" id="interests" checked>
-            Дайджест Доки (1 раз в месяц)
+            Дайджест Доки (один раз в месяц)
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="checkbox" name="interest" value="dream-job" id="interests" checked>
@@ -136,23 +137,29 @@
         <p class="subscribe-settings__note">Мы готовим новые тематические рассылки. Со временем они дополнят этот список, и вы сможете выбрать, что читать. Об обновлениях будем сообщать в Дайджесте.</p>
       </div>
       <div class="subscribe-settings__row">
-        {# В спане ниже меняем сообщения под статус #}
-        <span class="form-with-status__status">Обрабатываем запрос</span>
         <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Подписаться</button>
+        {# Ниже меняем сообщения под статус #}
+        <p role="status" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</p>
+        <p role="status" class="success-text" id="subscribe-success">Вы подписались на рассылку, ура 🎉</p>
+        <p role="alert" class="error-text" data-state="error" id="subscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте подписаться ещё раз.</p>
       </div>
     </form>
 
     <section class="unsubscribe-section subscribe-settings">
-      <p>Здесь можно отписаться от рассылки U×ᴥ×U</p>
+      <p>Здесь можно отписаться от рассылки <span aria-hidden="true">U×ᴥ×U</span></p>
       <form class="subscribe-page__unsubscribe unsubscribe__form form-with-status" action="">
-        <label class="unsubscribe__label">
-          <input type="text" name="reason" class="unsubscribe__input subscribe-settings__input" placeholder="Слишком часто приходят письма">
-          <span class="unsubscribe__hint subscribe-settings__hint">Расскажете что не понравилось?</span>
-        </label>
         <div class="unsubscribe__row">
+          <label class="unsubscribe__label">
+            <input type="text" name="reason" class="unsubscribe__input subscribe-settings__input" placeholder="Например, слишком часто приходят письма">
+            <span class="unsubscribe__hint subscribe-settings__hint">Расскажете, что не понравилось?</span>
+          </label>
           <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Отписаться</button>
-          {# В спане ниже меняем сообщения под статус #}
-          <span class="form-with-status__status">Обрабатываем запрос</span>
+        </div>
+        {# Ниже меняем сообщения под статус #}
+        <div class="unsubscribe__status">
+          <p role="status" class="progress-text" id="usubscribe-progress">Отписываем от рассылки ⌛</p>
+          <p role="status" class="success-text" id="usubscribe-success">Вы отписались от рассылки ☹️</p>
+          <p role="alert" class="error-text" data-state="error" id="usubscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте отписаться ещё раз.</p>
         </div>
       </form>
     </section>

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -26,7 +26,7 @@
         <input type="hidden" name="active" value="false">
         <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" aria-invalid="false" required>
         <span class="subscribe-settings__hint">Ваш e-mail</span>
-        <p class="error-email-text" id="empty-field">Пожалуйста, введите почту 🐶</p>
+        <span class="error-email-text" id="empty-field">Пожалуйста, введите почту 🐶</span>
       </div>
       <div class="subscribe-settings__row">
         <fieldset class="subscribe-settings__fieldset">
@@ -139,9 +139,9 @@
       <div class="subscribe-settings__row">
         <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Подписаться</button>
         {# Ниже меняем сообщения под статус #}
-        <p role="status" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</p>
-        <p role="status" class="success-text" id="subscribe-success">Вы подписались на рассылку, ура 🎉</p>
-        <p role="alert" class="error-text" data-state="error" id="subscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте подписаться ещё раз.</p>
+        <span role="status" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</span>
+        <span role="status" class="success-text" id="subscribe-success">Вы подписались на рассылку, ура 🎉</span>
+        <span role="alert" class="error-text" data-state="error" id="subscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте подписаться ещё раз.</span>
       </div>
     </form>
 
@@ -157,9 +157,9 @@
         </div>
         {# Ниже меняем сообщения под статус #}
         <div class="unsubscribe__status">
-          <p role="status" class="progress-text" id="usubscribe-progress">Отписываем от рассылки ⌛</p>
-          <p role="status" class="success-text" id="usubscribe-success">Вы отписались от рассылки ☹️</p>
-          <p role="alert" class="error-text" data-state="error" id="usubscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте отписаться ещё раз.</p>
+          <span role="status" class="progress-text" id="usubscribe-progress">Отписываем от рассылки ⌛</span>
+          <span role="status" class="success-text" id="usubscribe-success">Вы отписались от рассылки ☹️</span>
+          <span role="alert" class="error-text" data-state="error" id="usubscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте отписаться ещё раз.</span>
         </div>
       </form>
     </section>

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -24,9 +24,8 @@
           Нам обязательно нужна ваша почта
         </label>
         <input type="hidden" name="active" value="false">
-        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" aria-invalid="false" required>
+        <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" aria-invalid="false" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
         <span class="subscribe-settings__hint">Ваш e-mail</span>
-        <span class="error-email-text" id="empty-field">Ой, вы забыли ввести почту 🐶</span>
       </div>
       <div class="subscribe-settings__row">
         <fieldset class="subscribe-settings__fieldset">

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -26,7 +26,7 @@
         <input type="hidden" name="active" value="false">
         <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" aria-invalid="false" required>
         <span class="subscribe-settings__hint">Ваш e-mail</span>
-        <span class="error-email-text" id="empty-field">Пожалуйста, введите почту 🐶</span>
+        <span class="error-email-text" id="empty-field">Ой, вы забыли ввести почту 🐶</span>
       </div>
       <div class="subscribe-settings__row">
         <fieldset class="subscribe-settings__fieldset">
@@ -136,7 +136,7 @@
         </fieldset>
         <p class="subscribe-settings__note">Мы готовим новые тематические рассылки. Со временем они дополнят этот список, и вы сможете выбрать, что читать. Об обновлениях будем сообщать в Дайджесте.</p>
       </div>
-      <div class="subscribe-settings__row">
+      <div class="subscribe-settings__row subscribe-settings__row--center">
         <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Подписаться</button>
         {# Ниже меняем сообщения под статус #}
         <span role="status" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</span>

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -18,8 +18,8 @@
     <p>Дока — это гид по веб-платформе. В справочнике можете найти ответы на повседневные вопросы, а в рассылках мы собираем тематические подборки, советы от экспертов, авторские и партнёрские колонки.</p>
     <p>Здесь можете подписаться и сразу рассказать немного о себе, чтобы мы настроили рассылку под ваши интересы.</p>
 
-    <form class="subscribe-page__subscribe subscribe-settings form-with-status" action="">
-      <p class="subscribe-settings__label">Настроить рассылку</p>
+    <form class="subscribe-page__subscribe subscribe-settings form-with-status" aria-labelledby="subscribe-label" action="">
+      <h2 class="subscribe-settings__title" id="subscribe-label">Настроить рассылку</h2>
       <div class="subscribe-settings__row">
         <input type="hidden" name="active" value="false">
         <input class="subscribe-settings__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" id="email" inputmode="email" autocomplete="email" pattern="[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$" required>
@@ -123,12 +123,12 @@
         <fieldset class="subscribe-settings__fieldset">
           <legend class="subscribe-settings__label">Мне интересно читать:</legend>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="checkbox" name="interest" value="digest" id="base" checked>
+            <input class="subscribe-settings__control" type="checkbox" name="interests" value="digest" id="base" checked>
             Дайджест Доки (один раз в месяц)
           </label>
           <label class="subscribe-settings__control-label">
-            <input class="subscribe-settings__control" type="checkbox" name="interest" value="dream-job" id="special" checked>
-            Спецпроект Доки «Трудоустройство» (по мере выхода глав)
+            <input class="subscribe-settings__control" type="checkbox" name="interests" value="dream-job" id="special" checked>
+            Спецпроект «Трудоустройство» (по выходу глав)
           </label>
         </fieldset>
         <p class="subscribe-settings__note">Мы готовим новые тематические рассылки. Со временем дополним список, и вы сможете выбрать не только <a href="https://dream-job.doka.guide">спецпроект про трудоустройство</a> и ежемесячный дайджест. Об обновлениях расскажем в дайджесте.</p>
@@ -136,15 +136,17 @@
       <div class="subscribe-settings__row subscribe-settings__row--center">
         <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Подписаться</button>
         {# Ниже меняем сообщения под статус #}
-        <p aria-live="polite" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</p>
-        <p aria-live="polite" class="success-text" id="subscribe-success">Вы подписались на рассылку, ура 🎉</p>
-        <p aria-live="assertive" class="error-text" data-state="error" id="subscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте подписаться ещё раз.</p>
+        <div class="subscribe__status">
+          <p aria-live="polite" class="progress-text" id="subscribe-progress">Подписываем на рассылку ⌛</p>
+          <p aria-live="polite" class="success-text" id="subscribe-success">Вы подписались на рассылку, ура 🎉</p>
+          <p aria-live="assertive" class="error-text" data-state="error" id="subscribe-error">Что-то пошло не так. Перезагрузите страницу и попробуйте подписаться ещё раз.</p>
+        </div>
       </div>
     </form>
 
-    <section class="unsubscribe-section subscribe-settings">
-      <p>Здесь можно отписаться от рассылки <span aria-hidden="true">U×ᴥ×U</span></p>
-      <form class="subscribe-page__unsubscribe unsubscribe__form form-with-status" action="">
+    <section class="unsubscribe-section">
+      <form class="subscribe-page__unsubscribe subscribe-settings unsubscribe__form form-with-status" aria-labelledby="unsubscribe-label" action="">
+        <h2 class="subscribe-settings__title" id="unsubscribe-label">Отписаться от рассылки <span aria-hidden="true">U×ᴥ×U</span></h2>
         <div class="unsubscribe__row">
           <div class="unsubscribe__field">
             <input type="text" name="reason" id="reason" class="unsubscribe__input subscribe-settings__input" placeholder="Например, слишком часто приходят письма">

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -130,10 +130,10 @@
           </label>
           <label class="subscribe-settings__control-label">
             <input class="subscribe-settings__control" type="checkbox" name="interest" value="dream-job" id="special" checked>
-            Спецпроект Доки «<a href="https://dream-job.doka.guide">Трудоустройство</a>» (по мере выхода глав)
+            Спецпроект Доки «Трудоустройство» (по мере выхода глав)
           </label>
         </fieldset>
-        <p class="subscribe-settings__note">Мы готовим новые тематические рассылки. Со временем они дополнят этот список, и вы сможете выбрать, что читать. Об обновлениях будем сообщать в Дайджесте.</p>
+        <p class="subscribe-settings__note">Мы готовим новые тематические рассылки. Со временем дополним список, и вы сможете выбрать не только <a href="https://dream-job.doka.guide">спецпроект про трудоустройство</a> и ежемесячный дайджест. Об обновлениях расскажем в дайджесте.</p>
       </div>
       <div class="subscribe-settings__row subscribe-settings__row--center">
         <button class="subscribe-settings__button text-control__button button button--invert" type="submit">Подписаться</button>


### PR DESCRIPTION
Решаю проблемы из комментария к #1172 и не только. Окно подписки не трогала, хотя проблема с ним была описана изначально.

Что исправила [на странице подписки на рассылку](https://platform-1188.dev.doka.guide/subscribe/):

- добавила атрибуты `required`, `pattern` и `autocomplete` для поля с почтой;
- добавила тексты ошибок для разных статусов (успех, ошибка, прогресс) для обеих форм, сделала их live regions;
- добавила стили для ошибок и других статусов;
- связала тексты ошибок с формами с помощью `aria-describedby`;
- добавила `outline-offset` для кнопок, а то при фокусе рамок вообще не видно;
- немного переписала тексты;
- поправила уехавшую влево кнопку «Подписаться» в Firefox;
- перекрасила прогрессбар (раньше был белым на светло-сером фоне), отключила его, когда отключена анимация в системе;
- убрала повторяющиеся `id`;
- убрала ссылку из чекбокса (скринридеры её не читают, а пользователи мышки могут случайно кликнуть по ссылке вместо лейбла и уйти на другую страницу);
- сделала лейблы и инпуты соседними элементами там, где можно (так лучше для скринридеров);
- сделала заголовки форм настоящими заголовками, стилизовала их, связала с формами с помощью `aria-labelledby`;
- слегка улучила стили для чекбоксов и радиокнопок на мобилках (теперь лейблы не уезжают под контролы).

## Как выглядит исправленное

![Было и стало](https://github.com/doka-guide/platform/assets/17615202/55fd8405-564d-4b09-aa90-1a9d0a511e84)

## Уехавшая кнопка в Firefox

![image 15](https://github.com/doka-guide/platform/assets/17615202/aa649b83-7b12-426d-aa55-ded949c01f4c)
