### PR TITLE
Добавляет лейблы авторов в раздел "На практике"

### DIFF
--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -70,7 +70,7 @@
                 url='/people/' + practiceAuthor.fileSlug + '/'
               ) }}
             </span>
-            &nbsp;советует
+            советует
           </div>
         </h3>
         <div class="practices__content {% if not practice.isLong %}practices__content--short{% endif %} content">

--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -6,6 +6,44 @@
   {% endif %}
 {% endmacro %}
 
+{% macro answerOrName(name, url) %}
+  {% if url %}
+    <a class="link font-theme--code" href="{{ url }}">{{ name }}</a>
+  {% else %}
+    <span class="font-theme--code">{{ name }}</span>
+  {% endif %}
+{% endmacro %}
+
+{% macro roleLabel(role) %}
+  {% set roleUrl = allRoles[role].url %}
+  {% if role.url %}
+    {% set roleUrl = role.url %}
+  {% endif %}
+  {% set roleTitle = allRoles[role].title %}
+  {% if role.title %}
+    {% set roleTitle = role.title %}
+  {% endif %}
+  {% set roleColor = allRoles[role].color %}
+  {% if role.color %}
+    {% set roleColor = role.color %}
+  {% endif %}
+  {% set roleBackground = allRoles[role].bgColor %}
+  {% if role.bgColor %}
+    {% set roleBackground = role.bgColor %}
+  {% endif %}
+  {% set roleHover = allRoles[role].hoverColor %}
+  {% if role.hoverColor %}
+    {% set roleHover = role.hoverColor %}
+  {% endif %}
+  {% set roleBorder = allRoles[role].border %}
+  {% if role.border %}
+    {% set roleBorder = role.border %}
+  {% endif %}
+  <a href="{{ roleUrl }}" class="practices__author-roles-link" style="--role-color: {{ roleColor }}; --role-bg-color: {{ roleBackground }}; --role-hover-color: {{ roleHover }}; --role-border-color: {{ roleBorder }}">
+    {{ roleTitle }}
+  </a>
+{% endmacro %}
+
 {% if practices.length > 0 %}
   <section class="practices" id="practices">
     {{ practicesAuthors.length }}
@@ -18,13 +56,22 @@
 
       <article id="practices-{{ practice.fileSlug }}">
         <h3 class="practices__author">
-          <span class="practices__author-name">
-            {{ practiceAuthorName(
-              name=(practiceAuthor.data.name or practice.fileSlug),
-              url='/people/' + practiceAuthor.fileSlug + '/'
-            ) }}
+          <span class="practices__author-roles">
+            {% for roleKey in practiceAuthor.data.roles %}
+              {{ roleLabel(
+                role=roleKey
+              ) }}
+            {% endfor %}
           </span>
-          советует
+          <div>
+            <span class="practices__author-name">
+              {{ practiceAuthorName(
+                name=(practiceAuthor.data.name or practice.fileSlug),
+                url='/people/' + practiceAuthor.fileSlug + '/'
+              ) }}
+            </span>
+            &nbsp;советует
+          </div>
         </h3>
         <div class="practices__content {% if not practice.isLong %}practices__content--short{% endif %} content">
           <div class="practices__summary">

--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -63,7 +63,7 @@
               ) }}
             {% endfor %}
           </span>
-          <div class="practices__author-introduction">
+          <span class="practices__author-introduction">
             <span class="practices__author-name">
               {{ practiceAuthorName(
                 name=(practiceAuthor.data.name or practice.fileSlug),
@@ -71,7 +71,7 @@
               ) }}
             </span>
             советует
-          </div>
+          </span>
         </h3>
         <div class="practices__content {% if not practice.isLong %}practices__content--short{% endif %} content">
           <div class="practices__summary">

--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -63,7 +63,7 @@
               ) }}
             {% endfor %}
           </span>
-          <div>
+          <div class="practices__author-introduction">
             <span class="practices__author-name">
               {{ practiceAuthorName(
                 name=(practiceAuthor.data.name or practice.fileSlug),

--- a/src/includes/questions.njk
+++ b/src/includes/questions.njk
@@ -78,7 +78,7 @@
                     ) }}
                   {% endfor %}
                 </span>
-                <div>
+                <div class="answer__author-introduction">
                   <span class="answer__author-name">
                     {{ answerOrName(
                       name=(answerAuthor.data.name or answer.fileSlug),

--- a/src/includes/questions.njk
+++ b/src/includes/questions.njk
@@ -85,7 +85,7 @@
                       url='/people/' + answerAuthor.fileSlug + '/'
                     ) }}
                   </span>
-                  &nbsp;отвечает
+                  отвечает
                 </div>
               </h3>
               <div class="answer__content {% if not answer.isLong %}answer__content--short{% endif %} content">

--- a/src/includes/questions.njk
+++ b/src/includes/questions.njk
@@ -78,7 +78,7 @@
                     ) }}
                   {% endfor %}
                 </span>
-                <div class="answer__author-introduction">
+                <span class="answer__author-introduction">
                   <span class="answer__author-name">
                     {{ answerOrName(
                       name=(answerAuthor.data.name or answer.fileSlug),
@@ -86,7 +86,7 @@
                     ) }}
                   </span>
                   отвечает
-                </div>
+                </span>
               </h3>
               <div class="answer__content {% if not answer.isLong %}answer__content--short{% endif %} content">
                 <div class="answer__summary content">

--- a/src/libs/role-constructor/collection.json
+++ b/src/libs/role-constructor/collection.json
@@ -9,7 +9,7 @@
   },
   "praktikum-mentor": {
     "title": "Наставник Практикума",
-    "url": "https://practicum.yandex.ru/catalog/programming/",
+    "url": "https://practicum.yandex.ru/catalog/programming/?utm_source=pr&utm_medium=content&utm_campaign=doka_content",
     "color": "hsl(0 0% 100%)",
     "bgColor": "hsl(0 0% 0%)",
     "hoverColor": "hsl(0 0% 30%)",
@@ -17,7 +17,7 @@
   },
   "practicum-contributor": {
     "title": "Контрибьютор Практикума",
-    "url": "https://practicum.yandex.ru/catalog/programming/",
+    "url": "https://practicum.yandex.ru/catalog/programming/?utm_source=pr&utm_medium=content&utm_campaign=doka_content",
     "color": "hsl(0 0% 100%)",
     "bgColor": "hsl(0 0% 0%)",
     "hoverColor": "hsl(0 0% 30%)",

--- a/src/styles/blocks/answer.css
+++ b/src/styles/blocks/answer.css
@@ -6,7 +6,7 @@
   display: inline-flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 10px 20px;
+  gap: 10px 0.8em;
   font-size: var(--font-size-headline-3);
   line-height: var(--font-size-headline-3);
 }
@@ -39,6 +39,10 @@
 
 .answer__author-roles-link:hover {
   background-color: var(--role-hover-color);
+}
+
+.answer__author-name {
+  margin-inline-end: 0.5em;
 }
 
 .answer__author-name * {

--- a/src/styles/blocks/practices.css
+++ b/src/styles/blocks/practices.css
@@ -7,6 +7,43 @@
   margin-bottom: 0;
 }
 
+.practices__author {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px 20px;
+}
+
+.practices__author-roles {
+  --role-color: hsl(0 0% 0%);
+  --role-bg-color: hsl(0 0% 100%);
+  --role-hover-color: hsl(0 0% 94%);
+  --role-border-color: hsl(0 0% 0%);
+  align-self: center;
+  display: flex;
+}
+
+.practices__author-roles:not(:has(.practices__author-roles-link)) {
+  display: none;
+}
+
+.practices__author-roles-link {
+  font-size: calc(var(--font-size-s) * 1.25);
+  line-height: var(--font-line-height-s);
+  padding: 4px 18px;
+  text-decoration: none;
+  width: max-content;
+  border-width: 1px;
+  border-style: solid;
+  color: var(--role-color);
+  background-color: var(--role-bg-color);
+  border-color: var(--role-border-color);
+}
+
+.practices__author-roles-link:hover {
+  background-color: var(--role-hover-color);
+}
+
 .practices__author-name > * {
   font-family: 'Spot Mono', monospace;
   font-weight: 300;

--- a/src/styles/blocks/practices.css
+++ b/src/styles/blocks/practices.css
@@ -11,7 +11,7 @@
   display: inline-flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 10px 20px;
+  gap: 10px 0.8em;
 }
 
 .practices__author-roles {
@@ -42,6 +42,10 @@
 
 .practices__author-roles-link:hover {
   background-color: var(--role-hover-color);
+}
+
+.practices__author-name {
+  margin-inline-end: 0.5em;
 }
 
 .practices__author-name > * {

--- a/src/transforms/toc-transform.js
+++ b/src/transforms/toc-transform.js
@@ -1,4 +1,5 @@
 const HeadingHierarchy = require('../libs/heading-hierarchy/heading-hierarchy')
+const roles = require('../libs/role-constructor/collection.json')
 
 // генерация оглавления
 /**
@@ -19,6 +20,18 @@ module.exports = function (window) {
   )
     // не учитываем заголовки, которые лежат внутри тегов details, внутри советов и внутри ответов
     .filter((title) => !title.closest('details, .practices__content, .question__response'))
+    // исключаем роль из заголовка
+    .map((title) => {
+      for (let i = 0; i < Object.keys(roles).length; i++) {
+        const role = roles[Object.keys(roles)[i]].title
+        if (title.textContent.includes(role)) {
+          const titleWithoutRole = title.cloneNode(true)
+          titleWithoutRole.textContent = titleWithoutRole.textContent.replace(role, '')
+          return titleWithoutRole
+        }
+      }
+      return title
+    })
 
   const hierarchy = HeadingHierarchy.createHierarchy(headings)
   articleNavContent.innerHTML = HeadingHierarchy.render(hierarchy)


### PR DESCRIPTION
Добавила лейблы для авторов в разделе "На практике", точно такие же, как в разделе "На собеседовании". Так как в последнем были предусмотрены лейблы для редакции, они появились повсеместно. Также заменила ссылку в лейбле на размеченную, чтобы мы смогли понять, есть ли переходы.

![image](https://github.com/doka-guide/platform/assets/29401439/ce213a95-8618-431d-b42a-a314be37aafd)

Сделала точно так же, как сделано в "На собеседовании", скопировав код. Не уверена, нужно ли это дело отрефакторить и сделать реиспользуемый стиль "ответов" в любом разделе.

💔 Есть проблема, с которой мне нужна помощь. Текст лейблов добавляется в оглавление:

![image](https://github.com/doka-guide/platform/assets/29401439/4f55c446-1f7c-4ee5-9f6e-2dba804be68e)

Не могу убрать :(

https://platform-1189.dev.doka.guide/css/grid-guide/#na-praktike