### PR TITLE
Меняет вывод советов/ответов на странице автора

### DIFF
--- a/src/views/person.11tydata.js
+++ b/src/views/person.11tydata.js
@@ -97,13 +97,25 @@ module.exports = {
     },
 
     isOnlyWithPractice: function (data) {
-      const { personId, docsByPerson } = data
-      return !docsByPerson[personId]
+      const { personId, practicesByPerson, docsByPerson } = data
+      if (docsByPerson[personId] && practicesByPerson[personId]) {
+        const docsCategories = Object.keys(docsByPerson[personId])
+        const answersCategories = Object.keys(practicesByPerson[personId])
+        return !!answersCategories.filter((a) => !docsCategories.includes(a)).length
+      } else {
+        return !docsByPerson[personId] && !!practicesByPerson[personId]
+      }
     },
 
     isOnlyWithAnswer: function (data) {
-      const { personId, docsByPerson } = data
-      return !docsByPerson[personId]
+      const { personId, answersByPerson, docsByPerson } = data
+      if (docsByPerson[personId] && answersByPerson[personId]) {
+        const docsCategories = Object.keys(docsByPerson[personId])
+        const answersCategories = Object.keys(answersByPerson[personId])
+        return !!answersCategories.filter((a) => !docsCategories.includes(a)).length
+      } else {
+        return !docsByPerson[personId] && !!answersByPerson[personId]
+      }
     },
 
     articlesIndex: function (data) {


### PR DESCRIPTION
Возникала ошибка с выводов советов и ответов на странице участника в том случае, если категории материалов, над которыми работал участник не совпадали с категориями ответов и советов.

Пример страницы участника на сайте:

https://doka.guide/people/ra1nbow1/

хотя ответ есть в:

https://doka.guide/a11y/chto-takoe-a11y/#matvey-romanov-otvechaet


Ссылка участника в превью для проверки:

[/people/ra1nbow1/](https://platform-1189.dev.doka.guide/people/ra1nbow1/)

