### PR TITLE
Исправляет проблему медленной и постоянной анимации фиксированной шапки при скролле.

### DIFF
--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -216,6 +216,7 @@ class Header extends BaseComponent {
     const currentScroll = window.scrollY
     const isScrollingDown = currentScroll > lastScroll
     const isHeaderOnTop = currentScroll === 0
+    const minimumScrollDistance = 180
     this.state.lastScroll = currentScroll
 
     if (isHeaderOnTop) {
@@ -238,7 +239,7 @@ class Header extends BaseComponent {
         this.hideHeader()
       }
     } else {
-      if (!this.isFixed && !this.isMainPage) {
+      if (!this.isFixed && !this.isMainPage && lastScroll - currentScroll >= minimumScrollDistance) {
         this.showHeader()
       }
     }

--- a/src/styles/blocks/article.css
+++ b/src/styles/blocks/article.css
@@ -247,7 +247,7 @@
 
   .article__aside--offset {
     --header-offset: calc(var(--header-height, 0) * 1px);
-    transition-duration: 0.6s;
+    transition-duration: 0.2s;
   }
 
   .article__persons {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -1,7 +1,7 @@
 .header {
   --header-bg-color: var(--accent-color, var(--color-background));
   --search-input-height: 0.7em;
-  --header-animation-time: 0.6s;
+  --header-animation-time: 0.2s;
   position: relative;
   z-index: 2;
   background-color: var(--color-background);


### PR DESCRIPTION
- Уменьшил время анимации, с 600 миллисекунд до 200, для шапки и бокового меню статьи. Значение в 300 миллисекунд, как предлагали в issue, показалось медленным, а моё в 125 - чересчур быстрым.

- Для появления фиксированной шапки при скролле наверх нужно прокрутить страницу минимум на 180 пикселей - мне это расстояние кажется комфортным для использования на телефоне и десктопе и в то же время не ломающим логику наличия фиксированной шапки.