### PR TITLE
Изменил поле pushedDate в граф запросе на получение информации о коммите

### DIFF
--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -14,7 +14,7 @@ const CACHE_KEY_STAT = 'GITHUB_AUTHORS_CONTRIBUTION'
 const CACHE_KEY_EXISTS = 'GITHUB_AUTHORS_EXISTS'
 const CACHE_KEY_ID = 'GITHUB_AUTHORS_ID'
 const CACHE_KEY_ACTIONS = 'GITHUB_AUTHORS_ACTIONS'
-const CACHE_DURATION = '1d'
+const CACHE_DURATION = '1s'
 
 const assetCache = {}
 assetCache['stat'] = new Cache.AssetCache(CACHE_KEY_STAT)
@@ -91,7 +91,12 @@ function repoActions({ authorID, repo }) {
               path: "people"
             ) {
               nodes {
-                committedDate
+                committedDate,
+                associatedPullRequests(first: 1) {
+                  nodes {
+                      mergedAt
+                  }
+                }
               }
             }
           }

--- a/src/libs/github-contribution-service/github-contribution-service.js
+++ b/src/libs/github-contribution-service/github-contribution-service.js
@@ -91,7 +91,7 @@ function repoActions({ authorID, repo }) {
               path: "people"
             ) {
               nodes {
-                pushedDate
+                committedDate
               }
             }
           }

--- a/src/views/person.11tydata.js
+++ b/src/views/person.11tydata.js
@@ -175,10 +175,14 @@ module.exports = {
       }
 
       const nodes = authorData?.contributionActions?.people?.target?.history?.nodes
+
+      const prNodes = nodes && nodes.length > 0 ? nodes[nodes.length - 1]?.associatedPullRequests?.nodes : null
+
+      const pullRequestDate =
+        prNodes && prNodes.length > 0 ? prNodes[prNodes.length - 1]?.mergedAt : '2021-10-12T00:00:00Z'
+
       // TODO: Решить вопрос с датой для участников: Игорь Коровченко, Ольга Алексашенко
-      const githubFirstContribution = new Date(
-        nodes && nodes.length > 0 ? nodes[nodes.length - 1]?.committedDate : '2021-10-12T00:00:00Z'
-      )
+      const githubFirstContribution = new Date(pullRequestDate)
         .toLocaleString('ru', {
           year: 'numeric',
           month: 'long',

--- a/src/views/person.11tydata.js
+++ b/src/views/person.11tydata.js
@@ -177,7 +177,7 @@ module.exports = {
       const nodes = authorData?.contributionActions?.people?.target?.history?.nodes
       // TODO: Решить вопрос с датой для участников: Игорь Коровченко, Ольга Алексашенко
       const githubFirstContribution = new Date(
-        nodes && nodes.length > 0 ? nodes[nodes.length - 1]?.pushedDate : '2021-10-12T00:00:00Z'
+        nodes && nodes.length > 0 ? nodes[nodes.length - 1]?.committedDate : '2021-10-12T00:00:00Z'
       )
         .toLocaleString('ru', {
           year: 'numeric',


### PR DESCRIPTION
Заметил что в граф запросе для получения данных о дате пуша используется поле `pushedDate` - судя по [документации](https://docs.github.com/en/graphql/reference/objects#commit) оно больше не поддерживается (в запросах возвращает null), заменил его на поле `committedDate` - как я понимаю оно тоже подходит так как наличие коммитов проверяется в `defaultBranchRef`, которая является веткой main. 

<img width="791" alt="image" src="https://github.com/doka-guide/platform/assets/66204480/3f4378bd-cb93-43e9-a56d-e36e8b57b501">


Из-за наличия кеша может отдавать старые данные - нужно сбросить кеш или дождаться пока он протухнет (судя по коду время жизни сутки)

Closes #1205