### PR TITLE
Первая серия изменений PWA

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -369,11 +369,6 @@ async function cacheStrategyImpl({ cacheKey, request, preloadResponsePromise, fa
     return new Response()
   }
 
-  // Игнорирует кеширование запросов методом POST
-  if (request.method === 'POST') {
-    return new Response()
-  }
-
   // Пробует загрузить ресурс из кеша
   const responseFromCache = await caches.match(request)
   if (responseFromCache) {

--- a/src/sw.js
+++ b/src/sw.js
@@ -359,12 +359,6 @@ async function cacheStrategyImpl({ cacheKey, request, preloadResponsePromise, fa
     return new Response()
   }
 
-  // Пробует загрузить ресурс из кеша
-  const responseFromCache = await caches.match(request)
-  if (responseFromCache) {
-    return responseFromCache
-  }
-
   let requestUrl = request.url
 
   // Обрабатывает URL для кеширование страниц, если адрес заканчивается на 'index.html'
@@ -379,6 +373,12 @@ async function cacheStrategyImpl({ cacheKey, request, preloadResponsePromise, fa
     if (preloadResponse) {
       cloneResponseInCache(cacheKey, requestUrl, preloadResponse)
       return preloadResponse
+    }
+
+    // Пробует загрузить ресурс из кеша
+    const responseFromCache = await caches.match(request)
+    if (responseFromCache) {
+      return responseFromCache
     }
 
     // Запрашиваемый пользователем ресурс загружается и помещается в кеш

--- a/src/sw.js
+++ b/src/sw.js
@@ -369,11 +369,6 @@ async function cacheStrategyImpl({ cacheKey, request, preloadResponsePromise, fa
     return new Response()
   }
 
-  // Игнорирует кеширование манифеста
-  if (request.url.endsWith('manifest.json')) {
-    return new Response()
-  }
-
   // Игнорирует кеширование страниц с параметрами GET запроса
   if (request.url.indexOf('.html?') > -1 || request.url.indexOf('.js?') > -1) {
     return new Response()

--- a/src/sw.js
+++ b/src/sw.js
@@ -364,11 +364,6 @@ async function cacheStrategyImpl({ cacheKey, request, preloadResponsePromise, fa
     return new Response()
   }
 
-  // Игнорирует кеширование Service Worker
-  if (request.url.endsWith('sw.js')) {
-    return new Response()
-  }
-
   // Игнорирует кеширование страниц с параметрами GET запроса
   if (request.url.indexOf('.html?') > -1 || request.url.indexOf('.js?') > -1) {
     return new Response()

--- a/src/sw.js
+++ b/src/sw.js
@@ -354,18 +354,8 @@ async function putPagesInCache(cacheKey, pages, loadRelated = true) {
 
 // Стратегия кеширования
 async function cacheStrategyImpl({ cacheKey, request, preloadResponsePromise, fallbackUrl }) {
-  // Игнорирует запросы на другие домены
-  if (!request.url.startsWith(self.location.origin)) {
-    return new Response()
-  }
-
   // Игнорирует запросы browser-sync в режиме отладки
   if (request.url.indexOf('browser-sync') > -1) {
-    return new Response()
-  }
-
-  // Игнорирует кеширование страниц с параметрами GET запроса
-  if (request.url.indexOf('.html?') > -1 || request.url.indexOf('.js?') > -1) {
     return new Response()
   }
 


### PR DESCRIPTION
По результатам тестирования стало понятно, что надо изменить следующее:
1. Добавить в кеш манифест.
2. Убрать предварительную обработку (возврат пустых ответов) для POST-запросов.
3. Убрать предварительную обработку (возврат пустых ответов) для GET-запросов.
4. Убрать отсылку запросов на сторонние ресурсы.
5. Изменить стратегию кеширования — сначала запрашивать ресурсу из сети, а потом уже запрашивать ресурс из кеша. Это нужно для получения максимально актуальной версии ресурсов, при это не экономя трафик.