### PR TITLE
Микрофикс рамок у практик и советов

### DIFF
--- a/src/styles/blocks/answer.css
+++ b/src/styles/blocks/answer.css
@@ -71,7 +71,6 @@
 .answer__content > .answer__summary {
   height: 110px;
   padding: var(--offset);
-  background-color: var(--color-background);
 }
 
 .answer__content .answer__toggler {

--- a/src/styles/blocks/practices.css
+++ b/src/styles/blocks/practices.css
@@ -45,7 +45,6 @@
 .practices__content > .practices__summary {
   height: 110px;
   padding: var(--offset);
-  background-color: var(--color-background);
 }
 
 .practices__content .practices__toggler {


### PR DESCRIPTION
**Что происходит**

Этот ПР фиксит вот эти маленькие пустоты в уголках практик и советов:

![image](https://github.com/doka-guide/platform/assets/29401439/be90cf97-547a-4ffd-8d23-605fc875d4b6)


**Где посмотреть**

Развернуть практику или совет на любой странице, где они есть, например "Функция" ([платформа](https://doka.guide/js/function/) / [превью](https://platform-1244.dev.doka.guide/js/function/)), промотать вниз. Левый и правый нижний угол.