### PR TITLE
Чинит оформление ссылок на главной

### DIFF
--- a/src/styles/blocks/footer.css
+++ b/src/styles/blocks/footer.css
@@ -47,6 +47,11 @@
 
 .footer-list__link_social {
   padding: 5px;
+  text-decoration: none;
+}
+
+.footer-list__link_social::after {
+  margin: 0;
 }
 
 .footer-list__link_social:hover {

--- a/src/styles/blocks/link.css
+++ b/src/styles/blocks/link.css
@@ -23,10 +23,6 @@
   --stroke-opacity: 0.1;
 }
 
-.online .link::after {
-  display: none;
-}
-
 .offline .link::after {
   content: ' ';
   display: inline-block;
@@ -40,17 +36,9 @@
   filter: invert(calc(var(--is-dark-theme-on) * 1));
 }
 
-.online .link--cached::after {
-  display: none;
-}
-
 .offline .link--cached::after {
   background-image: url('/images/assets/cached-link.svg');
   background-repeat: no-repeat;
-}
-
-.online .link--non-cached::after {
-  display: none;
 }
 
 .offline .link--non-cached {
@@ -60,4 +48,16 @@
 .offline .link--non-cached::after {
   background-image: url('/images/assets/non-cached-link.svg');
   opacity: var(--cached-opacity);
+}
+
+.online .link:not(.nav-list__link, .article-indexes-list__link)::after {
+  display: none;
+}
+
+.online .link--cached:not(.nav-list__link, .article-indexes-list__link)::after {
+  display: none;
+}
+
+.online .link--non-cached:not(.nav-list__link, .article-indexes-list__link)::after {
+  display: none;
 }


### PR DESCRIPTION
- Возвращает ховер-эффекты ссылкам в хэдере;
- Возвращает подчёркивания заголовкам разделов в нижней секции;
- Заодно убирает подчёркивания у ссылок на соцсети, потому что они странно выглядят;
- (пересортировывает правила, потому что линтер заставил).

![image](https://github.com/doka-guide/platform/assets/29401439/11a2cb4b-f17b-4adb-a2a9-66f185bb4676)

![image](https://github.com/doka-guide/platform/assets/29401439/f98296d9-1a48-4567-8559-372867151eaa)

![image](https://github.com/doka-guide/platform/assets/29401439/d7cc0a5a-e9e6-4882-8358-77483dfdac21)

