### PR TITLE
Поднимает версию web-features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "stylelint-config-standard": "^36.0.0",
         "terser": "^5.26.0",
         "transliteration": "^2.3.5",
-        "web-features": "^0.5.0"
+        "web-features": "^0.8.6"
       },
       "engines": {
         "node": ">=16",
@@ -15758,9 +15758,9 @@
       }
     },
     "node_modules/web-features": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-0.5.0.tgz",
-      "integrity": "sha512-FdBZZdaYfvAeR5G2KE0gL+/fiQ/OBvLgOk08wWyCYll81KwkYNetgHajjQMwGmpljURqdXn3rtd94bx6cA+r0w==",
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-0.8.6.tgz",
+      "integrity": "sha512-KsxoK0LewcD+kFyhr6yxyIN5xAaDUb2ZvJQJdwvHsfj57/WVy4Ufwi6bRr9OZB7VFn3t912J9Qa25pTGpi3GoA==",
       "dev": true
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "stylelint-config-standard": "^36.0.0",
     "terser": "^5.26.0",
     "transliteration": "^2.3.5",
-    "web-features": "^0.5.0"
+    "web-features": "^0.8.6"
   },
   "dependencies": {
     "@11ty/eleventy-plugin-vite": "^4.0.0",


### PR DESCRIPTION
Текущая версия пакета [web-features](https://github.com/web-platform-dx/web-features/releases/tag/v0.8.6) - 0.8.6 
включает много нового.
Например? у меня есть PR с доками по новым методам Set:
- https://github.com/doka-guide/content/pull/5400
- https://github.com/doka-guide/content/pull/5401
- 
я добавил там данные о baseline. С используемой версией 0.5.0 выглядет не очень:
![изображение](https://github.com/doka-guide/platform/assets/9317613/d468d33d-936d-4592-aeff-db16200e9ce1)

Предлагаю обновить версию web-features