### PR TITLE
Поднимает версию web-features до 1.0.0

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -270,7 +270,8 @@ module.exports = function (config) {
   })
 
   config.addCollection('webFeatures', async () => {
-    return (await import('web-features')).default
+    const { features } = await import('web-features')
+    return features
   })
 
   config.setLibrary('md', initMarkdownLibrary())

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "stylelint-config-standard": "^36.0.0",
         "terser": "^5.26.0",
         "transliteration": "^2.3.5",
-        "web-features": "^0.8.6"
+        "web-features": "^1.0.0"
       },
       "engines": {
         "node": ">=16",
@@ -15757,9 +15757,9 @@
       }
     },
     "node_modules/web-features": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-0.8.6.tgz",
-      "integrity": "sha512-KsxoK0LewcD+kFyhr6yxyIN5xAaDUb2ZvJQJdwvHsfj57/WVy4Ufwi6bRr9OZB7VFn3t912J9Qa25pTGpi3GoA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-1.0.0.tgz",
+      "integrity": "sha512-U/ppX0h851Fr8LbOVMybiuH3iGWGlPi+DYXoj6VkOvXJc6VgYpSdGDosduYl/4qvW6YNlZ4IaczLgqHqbaU25A==",
       "dev": true
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "stylelint-config-standard": "^36.0.0",
     "terser": "^5.26.0",
     "transliteration": "^2.3.5",
-    "web-features": "^0.8.6"
+    "web-features": "^1.0.0"
   },
   "dependencies": {
     "@11ty/eleventy-plugin-vite": "^4.0.0",


### PR DESCRIPTION
В текущей используемой версии 0.86 есть проблемы с отображением версии Firefox для новых методов `Set`.
Например:
doka.guide/js/set-union/
| main | PR |
|--------|--------|
| ![изображение](https://github.com/user-attachments/assets/bd43a68c-ef73-4940-965b-444e88593c09) | ![изображение](https://github.com/user-attachments/assets/d3289286-bf73-40a7-9932-ca419178e490) | 

Этот PR:
- Поднимает версию до 1.0.0
- Исправляет импорт из модуля `web-features`.
FYI: Начиная с версии 0.10 (предпоследний релиз) требуется использовать именованый импорт вместо дефолтного.

см: https://www.npmjs.com/package/web-features/v/0.10.0
https://github.com/web-platform-dx/web-features/releases/tag/v0.10.0