### PR TITLE
Прибивает подвал

### DIFF
--- a/src/styles/blocks/base.css
+++ b/src/styles/blocks/base.css
@@ -15,6 +15,9 @@
 }
 
 .base__body {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-block-size: 100dvh;
   margin: 0;
   padding-top: calc(var(--is-header-fixed) * var(--not-fixed-header-height, 0) * 1px);
 }


### PR DESCRIPTION
Close #1282 

Сделала `.body__base` гридом с нужными размерами колонок и минимальной высотой в `100dvh`. Теперь даже на «коротких страницах» футер прибит. Потестила на всех подвернувшихся страничках. Буду благодарна, если вы тоже посмотрите.

Превью (смотреть на маленьком масштабе для наглядности): https://platform-1283.dev.doka.guide/newsletters/