### PR TITLE
Корректирует отображение эмодзи в breadcrumbs

### DIFF
--- a/src/styles/blocks/breadcrumbs.css
+++ b/src/styles/blocks/breadcrumbs.css
@@ -20,3 +20,7 @@
   flex-shrink: 1;
   min-width: 0;
 }
+
+.breadcrumbs__item:last-child .breadcrumbs__text {
+  padding-right: calc(var(--header-font-letter-spacing) * -1);
+}

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -2,6 +2,7 @@
   --header-bg-color: var(--accent-color, var(--color-background));
   --search-input-height: 0.7em;
   --header-animation-time: 0.6s;
+  --header-font-letter-spacing: -0.06em;
   position: relative;
   z-index: 2;
   background-color: var(--color-background);
@@ -90,7 +91,7 @@
 
 .header__inner--main {
   font-size: var(--font-size-l);
-  letter-spacing: -0.06em;
+  letter-spacing: var(--header-font-letter-spacing);
   line-height: var(--font-line-height-l);
   font-family: var(--font-family);
 }
@@ -116,7 +117,7 @@
   grid-template-rows: var(--font-size-xl) repeat(3, auto);
   font-size: calc(var(--font-size-xl) * 0.95);
   line-height: calc(var(--font-line-height-xl) * 0.95);
-  letter-spacing: -0.06em;
+  letter-spacing: var(--header-font-letter-spacing);
   background-color: var(--color-background);
   transition:
     transform var(--header-animation-time) cubic-bezier(0.65, 0.05, 0.36, 1),


### PR DESCRIPTION
Если в конце названия статьи есть эмодзи, то ее правая часть обрезается в breadcrumbs в режиме прокрутки страницы.
Это видно в разделах спец проекта "[Трудоустройство](https://dream-job.doka.guide/dream-job/)".

![Мотивационное письмо ✉️ — Трудоустройство — Дока 2024-08-11 19-03-48](https://github.com/user-attachments/assets/d3d8d132-d76c-41bf-b030-751ccdba0028)

**PS**: Ветка для проекта "Трудоустройство" [эта](https://github.com/doka-guide/platform/tree/landings-dream-job)? Туда нужно будет тоже влить правки.