### PR TITLE
Правит анимацию прозрачности у фильтра участников

### DIFF
--- a/src/styles/blocks/filter-panel.css
+++ b/src/styles/blocks/filter-panel.css
@@ -49,7 +49,7 @@
     max-height: calc(100vh - 108px);
     transition:
       transform 0.5s cubic-bezier(0.65, 0.05, 0.36, 1),
-      opacity calc(0.5s * (var(--is-filter-open)));
+      opacity 0.5s;
     background-color: hsl(0 0% var(--lightness));
   }
 


### PR DESCRIPTION
Привет! Заметил такой баг: на странице участников с мобильного фильтры выезжают плавно, а убираются без анимации. В `transition` указано `opacity calc(.5s*(var(--is-filter-open)))`, а в свою очередь переменная `--is-filter-open` принимает значения 0 или 1. Получается, `opacity` меняется то за 0.5s, то за 0, то есть без анимации :)

Оставил только 0.5s.