### PR TITLE
Упрощает получение значение свойства `article.data.cover.mobile`

### DIFF
--- a/src/scripts/modules/transform-article-data.js
+++ b/src/scripts/modules/transform-article-data.js
@@ -5,7 +5,7 @@ module.exports = function transformArticleData(article) {
     title: article.data.title,
     cover: article.data.cover ?? {},
     get imageLink() {
-      return Object.keys(this.cover).includes('mobile') ? `${this.cover.mobile}` : undefined
+      return this.cover?.mobile
     },
     description: article.data.description,
     link: `/${section}/${article.fileSlug}/`,


### PR DESCRIPTION
Упрощает xот-фикс для картинок на главной. см: https://github.com/doka-guide/platform/commit/4f92d3d8ec74a33a8019c6a09835439c90849a25

Задача: получить поле(строку) `article.data.cover.mobile`
Необходимо:
- убедиться что `article.data.cover` существует и является объектом
  - получить значение поля `mobile` и вернуть его
- иначе, вернуть `undefined`

Для этого можем использовать оператор `?.`

`article.data.cover?.mobile` - вернёт `undefined` если:
- `cover` не содержит `mobile`
- `cover` не является объектом

тесты:
```js
function imageLink() {
  return this.cover?.mobile
}

console.log(imageLink.call({ cover: { mobile: 'image' } })); // image
console.log(imageLink.call({ cover: {} })); // undefined
console.log(imageLink.call({ cover: [] })); // undefined
console.log(imageLink.call({ cover: 'str' })); // undefined
console.log(imageLink.call({ cover: 42 })); // undefined
console.log(imageLink.call({ cover: true })); // undefined
console.log(imageLink.call({})); // undefined
console.log(imageLink.call([])); // undefined
console.log(imageLink.call('str2')); // undefined
console.log(imageLink.call(null)); // undefined
```