### PR TITLE
Исправляет разметку списка ответов на странице участника

### DIFF
--- a/src/views/person.njk
+++ b/src/views/person.njk
@@ -223,17 +223,19 @@
               {{ articleIndexesMap[category].data.name }}
             </h2>
             <h3 class="articles-group__sub-title font-theme font-theme--code">{{ answersPersonRole }}</h3>
-            {% for articleList in answersInArticles[category] %}
-              <ul class="articles-group__list base-list">
-                {% for article in articleList | sort %}
-                  <li>
-                    <a class="articles-group__link link" href="/{{ category }}/{{ article.fileSlug }}/#na-sobesedovanii">
-                      {{ article.data.title | descriptionMarkdown | safe }}
-                    </a>
-                  </li>
-                {% endfor %}
-              </ul>
-            {% endfor %}
+            <ul class="articles-group__list base-list">
+              {% for articleList in answersInArticles[category] %}
+                <ul class="articles-group__list base-list">
+                  {% for article in articleList | sort %}
+                    <li>
+                      <a class="articles-group__link link" href="/{{ category }}/{{ article.fileSlug }}/#na-sobesedovanii">
+                        {{ article.data.title | descriptionMarkdown | safe }}
+                      </a>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endfor %}
+            </ul>
           </section>
         {% endfor %}
       {% endif %}

--- a/src/views/person.njk
+++ b/src/views/person.njk
@@ -204,15 +204,17 @@
               {{ articleIndexesMap[category].data.name }}
             </h2>
             <h3 class="articles-group__sub-title font-theme font-theme--code">{{ practicesPersonRole }}</h3>
-            {% for practice in practicesIndex[category] | sort %}
-              <ul class="articles-group__list base-list">
-                <li>
-                  <a class="articles-group__link link" href="/{{ category }}/{{ practice.fileSlug }}/#na-praktike">
-                    {{ practice.data.title | descriptionMarkdown | safe }}
-                  </a>
-                </li>
-              </ul>
-            {% endfor %}
+            <ul class="articles-group__list base-list">
+              {% for practice in practicesIndex[category] | sort %}
+                <ul class="articles-group__list base-list">
+                  <li>
+                    <a class="articles-group__link link" href="/{{ category }}/{{ practice.fileSlug }}/#na-praktike">
+                      {{ practice.data.title | descriptionMarkdown | safe }}
+                    </a>
+                  </li>
+                </ul>
+              {% endfor %}
+            </ul>
           </section>
         {% endfor %}
       {% endif %}

--- a/src/views/person.njk
+++ b/src/views/person.njk
@@ -206,15 +206,13 @@
             <h3 class="articles-group__sub-title font-theme font-theme--code">{{ practicesPersonRole }}</h3>
             <ul class="articles-group__list base-list">
               {% for practice in practicesIndex[category] | sort %}
-                <ul class="articles-group__list base-list">
-                  <li>
-                    <a class="articles-group__link link" href="/{{ category }}/{{ practice.fileSlug }}/#na-praktike">
-                      {{ practice.data.title | descriptionMarkdown | safe }}
-                    </a>
-                  </li>
-                </ul>
+                <li>
+                  <a class="articles-group__link link" href="/{{ category }}/{{ practice.fileSlug }}/#na-praktike">
+                    {{ practice.data.title | descriptionMarkdown | safe }}
+                  </a>
+                </li>
               {% endfor %}
-            </ul>
+            <ul>
           </section>
         {% endfor %}
       {% endif %}
@@ -227,15 +225,13 @@
             <h3 class="articles-group__sub-title font-theme font-theme--code">{{ answersPersonRole }}</h3>
             <ul class="articles-group__list base-list">
               {% for articleList in answersInArticles[category] %}
-                <ul class="articles-group__list base-list">
-                  {% for article in articleList | sort %}
-                    <li>
-                      <a class="articles-group__link link" href="/{{ category }}/{{ article.fileSlug }}/#na-sobesedovanii">
-                        {{ article.data.title | descriptionMarkdown | safe }}
-                      </a>
-                    </li>
-                  {% endfor %}
-                </ul>
+                {% for article in articleList | sort %}
+                  <li>
+                    <a class="articles-group__link link" href="/{{ category }}/{{ article.fileSlug }}/#na-sobesedovanii">
+                      {{ article.data.title | descriptionMarkdown | safe }}
+                    </a>
+                  </li>
+                {% endfor %}
               {% endfor %}
             </ul>
           </section>


### PR DESCRIPTION
Ошибка:
Допустим вклад участника в какой-либо раздел (HTML, CSS, и тп) это **только ответы на вопросы собеседования** (см. isOnlyWithAnswer() в файле person.11tydata.js)
В этом случае разметка списка для этой категории включает цикл по ответам участника (answersInArticles) состоящим из `<ul>`. Так как сами `<ul>` образуют список, требуется родительский элемент для установки отступов между ними.

Та же ситуация произойдёт если вклад участника в какую-либо категорию это  **только советы** (см. isOnlyWithPractice() в файле person.11tydata.js)

Исправляет: #1234

Доп. тестовая страница для примера: `/people/vitya-ne/` (см. вклад в раздел "Веб-платформа")
