### PR TITLE
Фиксирует меню так, чтобы всё работало как надо

### DIFF
--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -49,6 +49,7 @@
 
   .header--open .header__menu {
     position: fixed;
+    top: 55px;
   }
 }
 


### PR DESCRIPTION
Потестите все, пожалуйста, всё ли ок сейчас в Safari и Firefox: и на десктопе, и на мобилках для верности. Дропдаун не должен убегать от меню при скроле вниз.