### PR TITLE
Исправляет обработку перехода к поиску по клавише '/'

### DIFF
--- a/src/scripts/modules/header.js
+++ b/src/scripts/modules/header.js
@@ -88,6 +88,13 @@ class Header extends BaseComponent {
       this.checkSticky()
     }
 
+    document.addEventListener('keydown', (event) => {
+      // Firefox при нажатии Slash открывает свой поиск по странице
+      if (document.activeElement !== this.refs.input && (event.code === 'Slash' || event.code === 'NumpadDivide')) {
+        event.preventDefault()
+      }
+    })
+
     if (this.isMainPage) {
       document.addEventListener('keyup', (event) => {
         if (event.code === 'Slash' || event.code === 'NumpadDivide') {

--- a/src/scripts/modules/search.js
+++ b/src/scripts/modules/search.js
@@ -276,14 +276,13 @@ function init() {
       event.preventDefault()
     })
 
-    document.addEventListener('keydown', (event) => {
-      // Блокировка показа встроенного поиска в Firefox
-      if ((event.code === 'Slash' || event.code === 'NumpadDivide') && document.activeElement !== searchField) {
-        event.preventDefault()
-      }
-    })
-
     document.addEventListener('keyup', (event) => {
+      if (event.code === 'Slash' && document.activeElement !== searchField) {
+        queueMicrotask(() => {
+          searchField.focus()
+        })
+      }
+
       if (event.code === 'Enter' && document.activeElement === searchField) {
         queueMicrotask(() => {
           document.querySelector(SEARCH_HIT_LINK_SELECTOR)?.focus()


### PR DESCRIPTION
После мержа `Рефакторинг меню (#1191)` появились следующие сложности:
### Firefox (любая страница, включая страницу '/search'). раскладка - En
- нажатие `/` (или `NumpadDivide`) не приводит к активации Поиска. Открывется встроенный поиск FF. (1)🔴 
### Chrome (страница '/search').  раскладка - любая
- нажатие `/` (или `NumpadDivide`) не приводит к активации Поиска. (2)🔴 

Причины:
1. В коде `scripts/modules/header.js` нет обработчика `keydown` для подавления показа встроенного поиска FF (см. 1)
2. В коде `scripts/modules/search.js` в обработчике `keyup` нет кода для активации фокуса в строке поиска (см. 2)

@TatianaFokina , @skorobaeus посмотрите пожалуйста )

