### PR TITLE
Показывает строку поиска для средних экранов

### DIFF
--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -46,7 +46,9 @@
     position: sticky;
     width: 100%;
   }
+}
 
+@media (width >= 1024px) {
   .header--open .header__menu {
     position: fixed;
     top: 55px;


### PR DESCRIPTION
Исправляет проблему скрытой строки поиска для экранов с размерами: 768px < size < 1024px

main:
![изображение](https://github.com/user-attachments/assets/6a3e75bd-ee8a-41aa-a292-ddb013dc49a1)

Fix:
![изображение](https://github.com/user-attachments/assets/699c11f4-bd84-4002-9918-b8a4a7adf1eb)

@TatianaFokina, ещё патч !