### PR TITLE
Меняет партнёрский блок

### DIFF
--- a/src/styles/blocks/intro.css
+++ b/src/styles/blocks/intro.css
@@ -46,15 +46,25 @@
 }
 
 .intro__pitch--partner {
+  border: 1px solid hsl(var(--color-fade));
+  border-radius: 6px;
   background-color: transparent;
 }
 
 .intro__moto {
-  align-self: center;
+  align-self: self-start;
   font-family: var(--font-family);
   font-size: var(--font-size-l);
   font-weight: 300;
+  line-height: 1;
   margin: 0;
+}
+
+.intro__accent {
+  border-radius: 1em;
+  padding: 0 0.3em;
+  background-color: hsl(var(--color-fade));
+  white-space: nowrap;
 }
 
 .intro__footer {

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -21,7 +21,7 @@
         </p>
         <div class="intro__footer">
           <div class="intro__link">
-            📧 <a class="link" href="mailto:hi@doka.guide">Написать нам</a>
+            📧 <a class="link" href="mailto:hi@doka.guide?subject=Сотрудничество%20с%20Докой">Написать нам</a>
           </div>
         </div>
       </div>

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -15,15 +15,13 @@
       <h1 class="visually-hidden" id="main-content">Дока</h1>
       {{ promo(promoData.color, promoData.title, promoData.content, promoData.links) }}
       <div class="intro__pitch intro__pitch--partner">
-        <a target="_blank" rel="nofollow" href="https://practicum.yandex.ru/promo/courses/programming-reskilling/?utm_source=pr&utm_medium=content&utm_campaign=pr_content_programming-reskilling_doka">
-          <img class="intro__logo intro__logo--invertible" src="/images/partners/practicum.svg" alt="Практикум">
-        </a>
+        <h2 class="intro__moto font-theme--code">Дока <span class="intro__accent">ищет партнёров</span></h2>
         <p class="intro__description">
-          Работу редакции Доки поддерживает <a class="link" target="_blank" rel="nofollow" href="https://practicum.yandex.ru/promo/courses/programming-reskilling/?utm_source=pr&utm_medium=content&utm_campaign=pr_content_programming-reskilling_doka">Яндекс Практикум</a> — сервис онлайн-образования. Вместе мы помогаем сообществу развиваться и становиться лучше. Дока развивает площадку для накопления опыта, а Практикум помогает разработчикам изучать новое и расти.
+          Партнёрство с Докой полезно компаниям и проектам, которые разделяют ценности open-source. Предоставляя Доке полную или частичную поддержку, вы помогаете развивать русскоязычное фронтенд-сообщество.
         </p>
         <div class="intro__footer">
           <div class="intro__link">
-            <a class="link" href="/about/#otkuda-my-vzyalis">О партнёрстве</a>
+            📧 <a class="link" href="mailto:hi@doka.guide">Написать нам</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Было:

![image](https://github.com/user-attachments/assets/84402233-fd48-4a06-b0dc-cce7a05a850b)

Стало:

![image](https://github.com/user-attachments/assets/7c9fd37f-8363-4f6c-9a97-771870e30702)

Мерджить вместе с [#5497](https://github.com/doka-guide/content/pull/5497).
