### PR TITLE
Корректирует определение 'длинного' совета

### DIFF
--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -151,7 +151,8 @@ module.exports = {
       const formattedPractices = await Promise.all(
         filteredPractices.map(async (p) => {
           const practice = await p.template.inputContent
-          p['isLong'] = practice.split('\n').length > 2
+
+          p['isLong'] = practice.split('\n').filter((s) => s.length && s !== '\r').length > 2
           return p
         }),
       )


### PR DESCRIPTION
Корректирует получение флага `isLong`, определяющего что контент совета большой и его нужно показывать с кнопкой "+ Развернуть".

Перед подсчётом абзацев я откидываю пустые.

Текущий подход основанный на подсчёте абзацев (>2) не учитывал пустые абзацы как тут:
[Совет Алёны про outline — Прод](https://doka.guide/css/outline/#alyona-batickaya-sovetuet) || [Совет Алёны про outline — Превью](https://platform-1303.dev.doka.guide/css/outline/#alyona-batickaya-sovetuet), вот его код:
https://github.com/doka-guide/content/blob/main/css/outline/practice/solarrust.md?plain=1

Как оказалось "коротких" советов довольно много.
Я пробежася по нескольким  и убедился что карточка совета не занимает слишком много места.
Однако возможна ситуация (теоритически) когда совет - один очень большой абзац. Возможно стоит предусмотреть дополнительные способы определения `isLong`

Исправляет #1274