### PR TITLE
Исправляет 'Разделы на странице people всего в две колонки'

### DIFF
--- a/src/styles/blocks/person-page.css
+++ b/src/styles/blocks/person-page.css
@@ -91,7 +91,7 @@
   display: grid;
   gap: var(--offset);
   grid-template-columns: minmax(min(100%, 320px), 1fr);
-  max-width: 960px;
+  max-width: 1440px;
 }
 
 .person-page__group {
@@ -140,7 +140,7 @@
 @media (width >= 1024px) {
   .person-page {
     --sidebar-size: 245px;
-    --content-max-size: 36rem;
+    --content-max-size: 34rem;
   }
 
   .person-page__avatar {
@@ -169,10 +169,21 @@
   .person-page {
     --sidebar-size-end: 1fr;
   }
+
+  .person-page__articles {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  }
 }
 
 @media (width >= 1680px) {
+  .person-page__main {
+    grid-template-areas:
+      "avatar header   ."
+      "meta   articles articles"
+      ".      footer   footer"
+  }
+
   .person-page {
-    --sidebar-size: 320px;
+    --sidebar-size: 300px;
   }
 }


### PR DESCRIPTION
Добавляет возможность показывать список статей участника в 3 или 4 колонки на больших разрешениях.

Спасибо @StarHamster за предложенное решение

Я немного изменил его по причине:
- "скачка" с 4 колонок на 3 при ресайзе с `> 1440px` до `>1680px`
- резкого сокращения ширины `person-page__header` на точке `1440px`

Вот как получилось если посмотреть для примера на страницу Светы:

<details><summary>1400px</summary>
![image](https://github.com/user-attachments/assets/6a8fe22d-0975-453e-a002-8a7dfe5d5929)
</details> 

<details><summary>1500px</summary>
![image](https://github.com/user-attachments/assets/930e6fe0-6912-4bc4-86c5-d4d3f836bbeb)
</details> 

<details><summary>1700px</summary>
![image](https://github.com/user-attachments/assets/d4ffcb19-b0ce-43ff-a6ae-1a2e318122c1)
</details>

<details><summary>2048px</summary>
![image](https://github.com/user-attachments/assets/e883ff6d-d7a9-474b-8a35-ff716c877654)
</details> 

Исправляет #1000