### PR TITLE
Исправляет стили заголовка

### DIFF
--- a/src/styles/blocks/header-button.css
+++ b/src/styles/blocks/header-button.css
@@ -84,28 +84,28 @@
 }
 
 .header-button-icon--close {
-  width: 28px;
-  height: 28px;
-}
-
-@media (width >= 768px) {
-  .header-button-icon--close {
-    width: 30px;
-    height: 30px;
-  }
+  width: 30px;
+  height: 30px;
 }
 
 @media (width >= 1024px) {
   .header-button-icon--close {
-    width: 32px;
-    height: 32px;
+    width: 35px;
+    height: 35px;
+  }
+}
+
+@media (width >= 1366px) {
+  .header-button-icon--close {
+    width: 37px;
+    height: 37px;
   }
 }
 
 @media (width >= 1680px) {
   .header-button-icon--close {
-    width: 40px;
-    height: 40px;
+    width: 43px;
+    height: 43px;
   }
 }
 

--- a/src/styles/blocks/header-button.css
+++ b/src/styles/blocks/header-button.css
@@ -97,8 +97,8 @@
 
 @media (width >= 1366px) {
   .header-button-icon--close {
-    width: 37px;
-    height: 37px;
+    width: 36px;
+    height: 36px;
   }
 }
 

--- a/src/styles/blocks/header-button.css
+++ b/src/styles/blocks/header-button.css
@@ -84,28 +84,28 @@
 }
 
 .header-button-icon--close {
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
+}
+
+@media (width >= 768px) {
+  .header-button-icon--close {
+    width: 30px;
+    height: 30px;
+  }
 }
 
 @media (width >= 1024px) {
   .header-button-icon--close {
-    width: 35px;
-    height: 35px;
-  }
-}
-
-@media (width >= 1366px) {
-  .header-button-icon--close {
-    width: 37px;
-    height: 37px;
+    width: 32px;
+    height: 32px;
   }
 }
 
 @media (width >= 1680px) {
   .header-button-icon--close {
-    width: 43px;
-    height: 43px;
+    width: 40px;
+    height: 40px;
   }
 }
 

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -150,7 +150,7 @@
 }
 
 @media (width >= 1680px) {
-  .header__controls .header__search {
+  .header__controls .header__search, .header__controls .header__buttons {
     position: relative;
     top: -2px;
   }

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -51,6 +51,10 @@
 @media (width >= 1024px) {
   .header--open .header__menu {
     position: fixed;
+    top: 75px;
+  }
+
+  .header--open .header__controls--shrink + .header__menu {
     top: 55px;
   }
 }
@@ -58,6 +62,10 @@
 @media (width >= 1366px) {
   .header--open .header__menu {
     position: fixed;
+    top: 76px;
+  }
+
+  .header--open .header__controls--shrink + .header__menu {
     top: 56px;
   }
 }
@@ -65,6 +73,10 @@
 @media (width >= 1680px) {
   .header--open .header__menu {
     position: fixed;
+    top: 83px;
+  }
+
+  .header--open .header__controls--shrink + .header__menu {
     top: 63px;
   }
 }
@@ -114,6 +126,7 @@
 
 .header--open .header__controls {
   background-color: var(--color-background);
+  transition: none;
 }
 
 .header__divider {

--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -55,6 +55,20 @@
   }
 }
 
+@media (width >= 1366px) {
+  .header--open .header__menu {
+    position: fixed;
+    top: 56px;
+  }
+}
+
+@media (width >= 1680px) {
+  .header--open .header__menu {
+    position: fixed;
+    top: 63px;
+  }
+}
+
 /* содержимое главного меню (без дропдауна) */
 .header__controls {
   --letter-spacing: -0.06em;

--- a/src/styles/blocks/hotkey.css
+++ b/src/styles/blocks/hotkey.css
@@ -18,7 +18,7 @@
   }
 }
 
-@media not all and (width >= 768px) {
+@media not all and (width >= 1024px) {
   .hotkey {
     display: none;
   }


### PR DESCRIPTION
Заметил несколько странностей в стилях при использовании поиска не на главной странице:
1. Артефакт хоткей-кнопки при фокусе на поиске с разрешением x: 768px <= x <= 1024px

![изображение](https://github.com/user-attachments/assets/639b79ac-f73e-4459-9e4b-76a90ed006d7)

2. Иконка ✖️частично перекрывается при скроле на нескольких разрешениях

![изображение](https://github.com/user-attachments/assets/7dbebe81-f52c-4150-81bb-bc0d0c1c090a)

3. Меню наползает на заголовок в режиме поиска на разрешении >= 1680px

![изображение](https://github.com/user-attachments/assets/c77f8afe-1a43-4305-a40e-d35830dee03c)

Мой PR исправляет эти странности.
Тестировал в FF и Chrome на ноуте с Win 10. Экран: 1920x1080 масштаб 125%