### PR TITLE
Исправляет фон лэйбла языка в блоке кода

### DIFF
--- a/src/styles/blocks/block-code.css
+++ b/src/styles/blocks/block-code.css
@@ -23,7 +23,7 @@
   font-size: 0.6em;
   line-height: 1;
   letter-spacing: 0.025em;
-  background-color: hsl(var(--color-fade));
+  background-color: var(--code-lang-lable-background, hsl(var(--color-fade)));
   border-radius: 2em;
   transition: opacity 0.2s;
 }

--- a/src/styles/blocks/callout.css
+++ b/src/styles/blocks/callout.css
@@ -18,6 +18,7 @@
 
 .callout__content {
   --background-code-color: hsl(var(--color-base-background));
+  --code-lang-lable-background: var(--background-code-color);
   display: flex;
   flex-direction: column;
   flex: 1 1 320px;


### PR DESCRIPTION
Меняет фон лэйбла языка в блоке кода, в случае когда блок кода является частью callout

Проверил решение на вопросах для собеседования:

| main | fix |
|--------|--------|
|![image](https://github.com/user-attachments/assets/f365be4e-137d-42f3-9460-a118ca414cc7)|![image](https://github.com/user-attachments/assets/ac61c2c0-68d3-4365-b5d0-d19f26f7bc23)|
|![image](https://github.com/user-attachments/assets/40326971-670f-4ef4-a448-f93b89812707)|![image](https://github.com/user-attachments/assets/ffb1e503-24e6-4953-bc81-d5f7c961b2e6)|

Вставки блока кода в collaut в теле статьи не нашел, поэтому тестил путём вставки прямо в браузере (статья про память https://doka.guide/tools/trivial-memory-model).
| main | fix |
|--------|--------|
|![image](https://github.com/user-attachments/assets/00247938-bb9d-4ad4-81f8-08f18df4b003)|![image](https://github.com/user-attachments/assets/535283cb-dec3-4442-baf0-ab4dba04045c)|


Closes #1178 