### PR TITLE
Исправляет отображение baseline

### DIFF
--- a/src/includes/blocks/baseline.njk
+++ b/src/includes/blocks/baseline.njk
@@ -9,19 +9,14 @@
             </span>
             <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="yes">{{ baseline.versions[browser] }}</span>
           {% elif baseline.flagged[browser] %}
-            <span class="wdi-browser-compat__icon" data-browser="firefox">
-              <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, за флагом</span>
-            </span>
+            <span class="visually-hidden">{{ baseline.names[browser] }} {{ baseline.versions[browser] }}, за флагом</span>
             <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="flag">
             </span>
           {% elif baseline.preview[browser] %}
-            <span class="wdi-browser-compat__icon" data-browser="safari">
-              <span class="visually-hidden">{{ baseline.names[browser] }}, превью</span>
-            </span>
+            <span class="visually-hidden">{{ baseline.names[browser] }}, превью</span>
             <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="preview"></span>
           {% else %}
-            <span class="wdi-browser-compat__icon" data-browser="edge">
-              <span class="visually-hidden">{{ baseline.names[browser] }}, не поддерживается</span>
+            <span class="visually-hidden">{{ baseline.names[browser] }}, не поддерживается</span>
             </span>
             <span class="wdi-browser-compat__version" aria-hidden="true" data-compat="no"></span>
           {% endif %}

--- a/src/styles/blocks/baseline.css
+++ b/src/styles/blocks/baseline.css
@@ -53,6 +53,7 @@
   --size-2: clamp(0.75rem, 0.71rem + 0.18vw, 0.875rem);
   background-repeat: no-repeat no-repeat;
   background-position: center center;
+  background-origin: content-box;
   border-radius: 10000px;
   display: inline-block;
   font-size: var(--size-2);
@@ -69,6 +70,7 @@
 }
 
 .wdi-browser-compat__version[data-compat="flag"] {
+  padding: 4px;
   background-color: var(--wdi-warn-bg-color, #fff5e3);
   background-image: url("/images/baseline/flag.svg");
   color: var(--wdi-warn-color, #c34900);
@@ -81,6 +83,7 @@
 }
 
 .wdi-browser-compat__version[data-compat="preview"] {
+  padding: 2px;
   background-color: var(--wdi-warn-bg-color, #fff5e3);
   background-image: url("/images/baseline/preview.svg");
   color: var(--wdi-warn-color, #c34900);

--- a/src/styles/blocks/baseline.css
+++ b/src/styles/blocks/baseline.css
@@ -70,7 +70,6 @@
 }
 
 .wdi-browser-compat__version[data-compat="flag"] {
-  padding: 4px;
   background-color: var(--wdi-warn-bg-color, #fff5e3);
   background-image: url("/images/baseline/flag.svg");
   color: var(--wdi-warn-color, #c34900);

--- a/src/views/doc.11tydata.js
+++ b/src/views/doc.11tydata.js
@@ -276,19 +276,15 @@ module.exports = {
             },
             { chrome: 0, edge: 0, firefox: 0, safari: 0 },
           )
-        const supported = doc.data.baseline
-          .filter((g) => webFeatures[g.group].is_baseline)
-          .reduce(
-            (map, item) => {
-              for (const key of keys) {
-                if (!item[key]) {
-                  map[key] = false
-                }
-              }
-              return map
-            },
-            { chrome: true, edge: true, firefox: true, safari: true },
-          )
+        const supported = Object.keys(versions).reduce(
+          (map, item) => {
+            if (versions[item] === 0) {
+              map[item] = false
+            }
+            return map
+          },
+          { chrome: true, edge: true, firefox: true, safari: true },
+        )
         const flagged = { chrome: false, edge: false, firefox: false, safari: false }
         const preview = { chrome: false, edge: false, firefox: false, safari: false }
         return {


### PR DESCRIPTION
Сейчас, если фича поддерживается не всеми браузерами, baseline отображается так:

![image](https://github.com/user-attachments/assets/82384e12-7e19-405e-a89d-30c6e8698433)

Я предлагаю исправить и отображать так:

![image](https://github.com/user-attachments/assets/ed1138c8-459a-47ac-b666-4dda19ec4066)

ПР:
- исправляет формирование объекта `baseline.supported`. 
- исправялет отображение