### PR TITLE
Фиксит ошибку чтения координат значка

### DIFF
--- a/src/scripts/modules/person-badges.js
+++ b/src/scripts/modules/person-badges.js
@@ -238,7 +238,11 @@ function arrangeBadges(badges) {
 }
 
 function arrangeShapes(badges, coords) {
+  if (!badges.length) return
+  if (!coords) return
+
   badges.forEach((b, i) => {
+    if (!coords[i]) return
     b.parentElement.style = `--start-col: ${coords[i].x + 1}; --start-row: ${coords[i].y + 1};`
   })
 }


### PR DESCRIPTION
В консоль падает ошибка про чтение координато значка.

![CleanShot 2025-03-11 at 17 50 06](https://github.com/user-attachments/assets/aeea5637-1ec0-4630-80fa-1a3c265132f9)


Добавила проверок, чтобы все данные точно были. Локально ошибка пропала.