### PR TITLE
Обновляет версию пакета actions/cache@v4 для экшенов

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 20
       - name: Кэширование модулей
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 20
       - name: Кэширование модулей
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
Линтер ломается с ошибкой, ругается на старую версию пакета с кэшем

![CleanShot 2025-03-11 at 18 09 08](https://github.com/user-attachments/assets/4f7c0da9-ec56-4aea-ac68-23c9cd66a096)

Поменяла версию на 4.