### PR TITLE
Рефакторинг класса `SearchAPIClient` для поиска

### DIFF
--- a/src/scripts/core/search-api-client.js
+++ b/src/scripts/core/search-api-client.js
@@ -14,7 +14,6 @@ class SearchAPIClient {
     return fetch(url.toString() + '?' + params.toString(), {
       headers: {
         Accept: 'application/json',
-        Origin: 'https://doka.guide',
       },
     }).then((response) => response.json())
   }

--- a/src/scripts/core/search-api-client.js
+++ b/src/scripts/core/search-api-client.js
@@ -12,7 +12,6 @@ class SearchAPIClient {
       params.append(f.key, f.val)
     })
     return fetch(url.toString() + '?' + params.toString(), {
-      method: 'POST',
       headers: {
         Accept: 'application/json',
         Origin: 'https://doka.guide',

--- a/src/scripts/core/search-api-client.js
+++ b/src/scripts/core/search-api-client.js
@@ -11,7 +11,8 @@ class SearchAPIClient {
     filters.forEach((f) => {
       params.append(f.key, f.val)
     })
-    return fetch(url.toString() + '?' + params.toString(), {
+    url.search = params
+    return fetch(url, {
       headers: {
         Accept: 'application/json',
       },

--- a/src/scripts/core/search-api-client.js
+++ b/src/scripts/core/search-api-client.js
@@ -1,17 +1,4 @@
 class SearchAPIClient {
-  static get defaultSearchSettings() {
-    return {
-      getRankingInfo: true,
-      analytics: true,
-      enableABTest: false,
-      attributesToRetrieve: '*',
-      attributesToSnippet: '*:20',
-      responseFields: '*',
-      explain: '*',
-      facets: ['*', 'category', 'tags'],
-    }
-  }
-
   constructor(url) {
     this.url = url
   }


### PR DESCRIPTION
Правки:

1. Удаление настроек по умолчанию для Algolia, которая давно не используется
2. Использование http-метода `GET` вместо `POST`, так как лучше подходит по своей семантике получения данных и добавляет возможность кэширования результатов поиска в будущем
3. Удаляет задание заголовка `Origin`, так как его перепишет браузер на действительный
4. Упрощает сериализацию url в строку: знак `?`  будет проставляться сам