### PR TITLE
Поднимает версию web-features до 2.40.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "stylelint-config-standard": "^36.0.0",
         "terser": "^5.26.0",
         "transliteration": "^2.3.5",
-        "web-features": "^2.22.0"
+        "web-features": "^2.40.2"
       },
       "engines": {
         "node": ">=16",
@@ -15296,9 +15296,9 @@
       }
     },
     "node_modules/web-features": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.22.0.tgz",
-      "integrity": "sha512-IyUdFGAOq/O0cGuwopLTZoXn9eiXdaFVn3zpAvTubeCOSx2ln2VRlBVnlWsdl0rd9qXkndRuU+kYb2WRe/Tz/Q==",
+      "version": "2.40.2",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-2.40.2.tgz",
+      "integrity": "sha512-JuWRndnFSo0MoWkmXe9IRgkw46MdBLoynHJ85GHZZ96gJmjQV0ML5jbG8qi0qlWhfO+22hAnodKd/iBHLB5pUw==",
       "dev": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "stylelint-config-standard": "^36.0.0",
     "terser": "^5.26.0",
     "transliteration": "^2.3.5",
-    "web-features": "^2.22.0"
+    "web-features": "^2.40.2"
   },
   "dependencies": {
     "@11ty/eleventy-plugin-vite": "^4.0.0",


### PR DESCRIPTION
Обновляет версию web-features.

Текущая версия (2.22.0) пакета `web-features` содержит устаревшие данные.

Например:
[Поддержка атрибута `inert`](https://web-platform-dx.github.io/web-features-explorer/features/inert/) уже есть во всех браузерах:
![image](https://github.com/user-attachments/assets/5645b744-3fc3-4959-98f3-61313db3bd46)

а с текущей версии пакета:
![image](https://github.com/user-attachments/assets/b456a100-cbfe-4b7a-a536-b4306d3f1fdc)
