### PR TITLE
Добавляет обработку конкурентных запросов для поиска

### DIFF
--- a/src/scripts/core/search-api-client.js
+++ b/src/scripts/core/search-api-client.js
@@ -12,11 +12,24 @@ class SearchAPIClient {
       params.append(f.key, f.val)
     })
     url.search = params
+    this.abortController?.abort?.()
+    this.abortController = new AbortController()
     return fetch(url, {
       headers: {
         Accept: 'application/json',
       },
-    }).then((response) => response.json())
+      signal: this.abortController.signal,
+    })
+      .then((response) => response.json())
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return
+        }
+        return Promise.reject(error)
+      })
+      .finally(() => {
+        this.abortController = null
+      })
   }
 }
 


### PR DESCRIPTION
Данный PR устраненяет конкурентные запросы при поиске.

Что такое конкурентные запросы и какие баги вызывают?

Рассмотрим пример. Пользователь вбивает в поиск строку "**A**". Запрос уходит, но по некоторым причинам подвисает (большая нагрузка, сервер долго отвечает и др.). Далее пользователь вбивает другую строку "**B**". В этот раз сервер отвечает быстро, ответ приходит, рендерится результат запроса. В этот момент запрос "**A**" отвисает, приходит с ответом, рендерится результат для него. Получается несогласованность - в строке поиска один запрос, а показаны результаты для другого.

Также такая техника наряду с debounce снижает нагрузку на сервер, отменяя зависшие запросы.