### PR TITLE
Исправляет управление фокусом в карточках «На практике»

### DIFF
--- a/src/includes/practices.njk
+++ b/src/includes/practices.njk
@@ -26,7 +26,7 @@
           </span>
           советует
         </h3>
-        <div class="practices__content {% if not practice.isLong %}practices__content--short{% endif %} content">
+        <div class="practices__content {% if not practice.isLong %}practices__content--short{% endif %} content" tabindex="-1">
           <div class="practices__summary content">
             {{ practice.templateContent | safe }}
             {% if practice.isLong %}

--- a/src/scripts/modules/practices.js
+++ b/src/scripts/modules/practices.js
@@ -1,15 +1,17 @@
-function setTabIndex(list, newValue) {
-  for (let item of list) {
-    item.setAttribute('tabindex', newValue)
-  }
+const tabIndexActions = {
+  '-1': (element) => element.setAttribute('tabindex', '-1'),
+  0: (element) => element.removeAttribute('tabindex'),
 }
 
 function getActiveElements(container) {
   const allElements = []
   allElements.push(container.getElementsByClassName('block-code__inner'))
   allElements.push(container.getElementsByClassName('block-code__copy-button'))
+  allElements.push(container.getElementsByClassName('article-heading__copy-button'))
   allElements.push(container.getElementsByTagName('a'))
   allElements.push(container.getElementsByTagName('input'))
+  allElements.push(container.getElementsByTagName('details'))
+  allElements.push(container.getElementsByTagName('iframe'))
   for (let iframe of container.getElementsByTagName('iframe')) {
     allElements.push(iframe.contentWindow.document.getElementsByTagName('a'))
     allElements.push(iframe.contentWindow.document.getElementsByTagName('input'))
@@ -20,7 +22,9 @@ function getActiveElements(container) {
 function toggleTabIndex(container, newValue) {
   const activeElements = getActiveElements(container)
   activeElements.forEach((elements) => {
-    setTabIndex(elements, newValue)
+    for (const element of elements) {
+      tabIndexActions[newValue](element)
+    }
   })
 }
 
@@ -53,6 +57,7 @@ function togglePractice(event) {
     element.innerHTML = '– Свернуть'
     element.addEventListener('keydown', tabKeyPressed)
     toggleTabIndex(summaryContainer, '0')
+    contentContainer.focus()
   }
 }
 


### PR DESCRIPTION
Привет!

Заметила, что код предполагает, что в свёрнутом состоянии все интерактивные элементы карточки должны быть недоступны через таб, но на деле якоря заголовков остаются интерактивными. Погуляла по сайту ещё и заметила, что то же самое касается `<iframe>` и `<details>`, поэтому добавила их в `getActiveElements`. Возможно, в карточках может встречаться что-то ещё из такого интерактивного, что в теории легко упустить. Поправьте если что :)

Ещё из изменений:
- Сделала так, чтобы `tabindex` полностью снимался вместо проставления ему нулевого значения. Сделано это было в частности потому что `details` получал "двойной" фокус из-за `summary`, поэтому так мы как бы восстанавливаем нативное поведение.
- Добавила фокус на контент при раскрытии карточки. [Вот эта статья](https://www.makethingsaccessible.com/guides/build-a-show-more-accessible-disclosure-widget/) хорошо объясняет, почему это важно.

P.S. В процессе ещё обнаружила баг, связанный с фокусом, но не хочу слишком сильно раздувать этот PR, да и обсудила бы это сперва, потому что лично мне недостаёт понимания, почему именно так было реализовано. Но вообще я заметила, что `getActiveElements` зачем-то группирует элементы по типу, из-за чего таб внутри раскрытой карточки ходит не в том порядке, в каком элементы по факту идут на странице. Лично меня такое поведение как постоянного клавопользователя сбило с толку. Вдобавок это приводит к ошибке, когда, например, блоков с кодом в карточке нет, и фокусу дальше некуда уйти ([вот тут](https://doka.guide/css/font-weight/#na-praktike) это можно увидеть в действии). В чём идея такой группировки я тоже, честно говоря, не поняла. Предлагаю решить это через квери селектор, чтобы сохранить порядок.
P.P.S. Я уже чуть позже это заметила, но иногда зацикливание фокуса происходит, а иногда — нет. Так-то не до конца уверена, как правильно тут должно быть 🤔 Наверное, зацикливания вообще быть не должно т.к. мы не в модалке находимся, но послушала бы и другие мнения.