### PR TITLE
Отключает опцию linkify для markdown

### DIFF
--- a/src/markdown-it.js
+++ b/src/markdown-it.js
@@ -5,7 +5,7 @@ module.exports = () => {
   const md = markdownIt({
     html: true,
     breaks: true,
-    linkify: true,
+    linkify: false,
     highlight: function (str, lang) {
       const content = md.utils.escapeHtml(str)
       const LANG_ALIASES = {


### PR DESCRIPTION
Если в контенте писать что-то вроде `script.sh`, то markdown-it преобразует это в относительные ссылки.  Ссылки лучше создавать явно.

[Пример статьи](https://doka.guide/recipes/font-script/#gotovoe-reshenie) с некорректным поведением, фраза "я использую вот такой скрипт font.sh"