### PR TITLE
Автоматически добавляет шапку и футер в демки при открытии вне iframe

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ const rev = require('gulp-rev')
 const revRewrite = require('gulp-rev-rewrite')
 
 const { contentRepGithub, contentRepFolders } = require(path.join(__dirname, 'config/constants'))
+const { injectDemoFrame } = require('./src/libs/demo-frame/inject-demo-frame')
 
 const cloneContent = () => git.clone(contentRepGithub)
 
@@ -29,7 +30,7 @@ const makeLinks = shell.task(`node make-links.js --default`, {
 
 const styles = () => {
   return gulp
-    .src('src/styles/{index.css,index.sc.css,dark-theme.css}')
+    .src('src/styles/{index.css,index.sc.css,dark-theme.css,demo-frame.css}')
     .pipe(
       postcss([
         pimport,
@@ -59,7 +60,7 @@ const sw = () => {
 
 const scripts = () => {
   return gulp
-    .src('src/scripts/index.js')
+    .src(['src/scripts/index.js', 'src/scripts/demo-frame.js'])
     .pipe(
       esbuild({
         target: 'es2015',
@@ -115,9 +116,13 @@ const cacheReplace = () => {
 
 const cache = gulp.series(cacheHash, cacheReplace)
 
+// Demo frame
+
+const demoFrame = () => injectDemoFrame()
+
 exports.setupContent = gulp.series(cloneContent, makeLinks)
 
 exports.dropContent = () => del(['content', ...contentRepFolders.map((folder) => `src/${folder}`)])
 
 // Default
-exports.default = gulp.series(clean, styles, scripts, sw, cache)
+exports.default = gulp.series(clean, styles, scripts, sw, demoFrame, cache)

--- a/src/libs/__tests__/demo-frame.js
+++ b/src/libs/__tests__/demo-frame.js
@@ -1,0 +1,150 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { findDemoEntryFiles, resolveDemoData } = require('../demo-frame/inject-demo-frame')
+const { transformDemoHtml } = require('../demo-frame/transform-demo-html')
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'demo-frame-test-'))
+}
+
+function writeFile(filePath, contents) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, contents)
+}
+
+describe('findDemoEntryFiles', () => {
+  let root
+
+  beforeEach(() => {
+    root = makeTempDir()
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('finds demos/{name}/index.html one level under demos', () => {
+    writeFile(path.join(root, 'css/display/demos/example/index.html'), '<html></html>')
+
+    expect(findDemoEntryFiles(root)).toEqual([path.join(root, 'css/display/demos/example/index.html')])
+  })
+
+  it('ignores html files nested deeper than demos/{name}/', () => {
+    writeFile(path.join(root, 'js/window-history/demos/history-operations/index.html'), '<html></html>')
+    writeFile(path.join(root, 'js/window-history/demos/history-operations/about.html'), '<html></html>')
+    writeFile(path.join(root, 'css/view-transition/demos/mpa/articles/view-transition.html'), '<html></html>')
+
+    const found = findDemoEntryFiles(root)
+
+    expect(found).toEqual([path.join(root, 'js/window-history/demos/history-operations/index.html')])
+  })
+
+  it('ignores demo directories without an index.html', () => {
+    writeFile(path.join(root, 'css/clamp/demos/dynamic-width/code.html'), '<html></html>')
+
+    expect(findDemoEntryFiles(root)).toEqual([])
+  })
+})
+
+describe('resolveDemoData', () => {
+  let root
+  let distDir
+  let srcDir
+
+  beforeEach(() => {
+    root = makeTempDir()
+    distDir = path.join(root, 'dist')
+    srcDir = path.join(root, 'src')
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  it('resolves section, slug, author and accent from the owning article', () => {
+    writeFile(path.join(srcDir, 'css/display/index.md'), '---\ntitle: "display"\nauthors:\n  - solarrust\n---\n')
+    writeFile(path.join(srcDir, 'people/solarrust/index.md'), "---\nname: 'Алёна Батицкая'\n---\n")
+
+    const demoEntryPath = path.join(distDir, 'css/display/demos/example/index.html')
+
+    expect(resolveDemoData(demoEntryPath, { distDir, srcDir })).toEqual({
+      section: 'css',
+      slug: 'display',
+      authorUsername: 'solarrust',
+      authorName: 'Алёна Батицкая',
+      accent: 'hsl(209 100% 59%)',
+    })
+  })
+
+  it('uses a different accent for a different section', () => {
+    writeFile(path.join(srcDir, 'html/details/index.md'), '---\ntitle: "details"\nauthors:\n  - solarrust\n---\n')
+    writeFile(path.join(srcDir, 'people/solarrust/index.md'), "---\nname: 'Алёна Батицкая'\n---\n")
+
+    const demoEntryPath = path.join(distDir, 'html/details/demos/example/index.html')
+
+    expect(resolveDemoData(demoEntryPath, { distDir, srcDir }).accent).toBe('hsl(25 100% 59%)')
+  })
+
+  it('falls back to the username when the author profile is missing', () => {
+    writeFile(path.join(srcDir, 'css/display/index.md'), '---\ntitle: "display"\nauthors:\n  - unknown-author\n---\n')
+
+    const demoEntryPath = path.join(distDir, 'css/display/demos/example/index.html')
+
+    expect(resolveDemoData(demoEntryPath, { distDir, srcDir }).authorName).toBe('unknown-author')
+  })
+
+  it('returns null when the owning article cannot be resolved', () => {
+    const demoEntryPath = path.join(distDir, 'css/nonexistent/demos/example/index.html')
+
+    expect(resolveDemoData(demoEntryPath, { distDir, srcDir })).toBeNull()
+  })
+
+  it('returns null when the article has no authors', () => {
+    writeFile(path.join(srcDir, 'css/display/index.md'), '---\ntitle: "display"\n---\n')
+
+    const demoEntryPath = path.join(distDir, 'css/display/demos/example/index.html')
+
+    expect(resolveDemoData(demoEntryPath, { distDir, srcDir })).toBeNull()
+  })
+})
+
+describe('transformDemoHtml', () => {
+  const baseHtml = '<!DOCTYPE html><html lang="ru"><head><title>Демо</title></head><body><p>Привет</p></body></html>'
+  const data = {
+    section: 'css',
+    slug: 'display',
+    authorUsername: 'solarrust',
+    authorName: 'Алёна Батицкая',
+    accent: 'hsl(209 100% 59%)',
+  }
+
+  it('injects the shared stylesheet, script, logo and footer', () => {
+    const result = transformDemoHtml(baseHtml, data)
+
+    expect(result).toContain('href="/styles/demo-frame.css"')
+    expect(result).toContain('rel="stylesheet"')
+    expect(result).toContain('src="/scripts/demo-frame.js"')
+    expect(result).toContain('--demo-frame-accent: hsl(209 100% 59%)')
+    expect(result).toContain('class="demo-frame-logo"')
+    expect(result).toContain('class="demo-frame-footer"')
+    expect(result).toContain('href="https://doka.guide/css/display/"')
+    expect(result).toContain('href="https://doka.guide/people/solarrust/"')
+    expect(result).toContain('Алёна Батицкая')
+  })
+
+  it('is idempotent when run twice', () => {
+    const once = transformDemoHtml(baseHtml, data)
+    const twice = transformDemoHtml(once, data)
+
+    expect(twice).toBe(once)
+  })
+
+  it('preserves an existing inline body style', () => {
+    const htmlWithStyle = baseHtml.replace('<body>', '<body style="color: red">')
+    const result = transformDemoHtml(htmlWithStyle, data)
+
+    expect(result).toContain('color: red')
+    expect(result).toContain('--demo-frame-accent: hsl(209 100% 59%)')
+  })
+})

--- a/src/libs/demo-frame/inject-demo-frame.js
+++ b/src/libs/demo-frame/inject-demo-frame.js
@@ -1,0 +1,141 @@
+const fs = require('fs')
+const path = require('path')
+const frontMatter = require('gray-matter')
+const categoryColors = require('../../../config/category-colors')
+const { transformDemoHtml } = require('./transform-demo-html')
+
+const ROOT_DIR = path.join(__dirname, '..', '..', '..')
+const DIST_DIR = path.join(ROOT_DIR, 'dist')
+const SRC_DIR = path.join(ROOT_DIR, 'src')
+
+/**
+ * Ищет входные HTML-файлы демок — только demos/{имя}/index.html, ровно один
+ * уровень вложенности под demos/. Внутренние страницы демок (вложенная
+ * навигация, встроенные iframe с превью кода и т. п.) сознательно не трогаем:
+ * у них нет своей отдельной "статьи-владельца", и чужая шапка/подвал там
+ * не нужны.
+ *
+ * @param {string} rootDir
+ * @returns {string[]}
+ */
+function findDemoEntryFiles(rootDir) {
+  const results = []
+
+  function walk(dir) {
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue
+      }
+
+      const fullPath = path.join(dir, entry.name)
+
+      if (entry.name === 'demos') {
+        let demoDirs = []
+        try {
+          demoDirs = fs.readdirSync(fullPath, { withFileTypes: true })
+        } catch {
+          demoDirs = []
+        }
+
+        for (const demoDir of demoDirs) {
+          if (!demoDir.isDirectory()) {
+            continue
+          }
+
+          const indexPath = path.join(fullPath, demoDir.name, 'index.html')
+          if (fs.existsSync(indexPath)) {
+            results.push(indexPath)
+          }
+        }
+
+        continue
+      }
+
+      walk(fullPath)
+    }
+  }
+
+  walk(rootDir)
+  return results
+}
+
+/**
+ * По пути dist/{section}/{slug}/demos/{name}/index.html находит исходную
+ * статью и автора, чтобы собрать данные для шапки/подвала демки.
+ * Если статья или автор не резолвятся — возвращает null, вызывающий код
+ * должен пропустить такой файл, не обрушая сборку.
+ *
+ * @param {string} demoEntryPath
+ * @param {{ distDir: string, srcDir: string }} dirs
+ * @returns {{ section: string, slug: string, authorUsername: string, authorName: string, accent: string } | null}
+ */
+function resolveDemoData(demoEntryPath, { distDir, srcDir } = { distDir: DIST_DIR, srcDir: SRC_DIR }) {
+  const relFromDist = path.relative(distDir, demoEntryPath)
+  const parts = relFromDist.split(path.sep)
+  const demosIndex = parts.indexOf('demos')
+
+  if (demosIndex < 2) {
+    return null
+  }
+
+  const articleRelParts = parts.slice(0, demosIndex)
+  const [section] = articleRelParts
+  const slug = articleRelParts.slice(1).join('/')
+
+  const articleMdPath = path.join(srcDir, ...articleRelParts, 'index.md')
+  if (!fs.existsSync(articleMdPath)) {
+    return null
+  }
+
+  let articleData
+  try {
+    articleData = frontMatter(fs.readFileSync(articleMdPath, 'utf-8')).data
+  } catch {
+    return null
+  }
+
+  const authors = articleData.authors
+  const authorUsername = Array.isArray(authors) ? authors[0] : authors
+  if (!authorUsername) {
+    return null
+  }
+
+  let authorName = authorUsername
+  try {
+    const personMdPath = path.join(srcDir, 'people', authorUsername, 'index.md')
+    authorName = frontMatter(fs.readFileSync(personMdPath, 'utf-8')).data.name || authorUsername
+  } catch {
+    // Профиль автора не резолвится — используем логин, сборку не обрушаем.
+  }
+
+  const { light: accent } = categoryColors[section] || categoryColors.default
+
+  return { section, slug, authorUsername, authorName, accent }
+}
+
+/**
+ * Проходит по всем демкам в dist/ и внедряет в них автоматическую шапку/подвал.
+ */
+async function injectDemoFrame() {
+  const demoFiles = findDemoEntryFiles(DIST_DIR)
+
+  for (const filePath of demoFiles) {
+    const data = resolveDemoData(filePath, { distDir: DIST_DIR, srcDir: SRC_DIR })
+    if (!data) {
+      continue
+    }
+
+    const html = fs.readFileSync(filePath, 'utf-8')
+    const updatedHtml = transformDemoHtml(html, data)
+    fs.writeFileSync(filePath, updatedHtml)
+  }
+}
+
+module.exports = { injectDemoFrame, findDemoEntryFiles, resolveDemoData }

--- a/src/libs/demo-frame/transform-demo-html.js
+++ b/src/libs/demo-frame/transform-demo-html.js
@@ -1,0 +1,55 @@
+const { parseHTML } = require('linkedom')
+
+/**
+ * Внедряет в HTML демки автоматическую шапку (ссылка на doka.guide) и подвал
+ * (ссылка на статью и на автора). Видимость управляется исключительно через
+ * src/scripts/demo-frame.js (класс .demo-frame--visible на <html>), без
+ * query-параметров — демка не должна ничего знать про embed.
+ *
+ * Идемпотентна: повторный вызов на уже обработанном файле возвращает его
+ * без изменений (gulp может пересобирать dist без предварительной чистки).
+ *
+ * @param {string} html — исходный HTML демки
+ * @param {{ section: string, slug: string, authorUsername: string, authorName: string, accent: string }} data
+ * @returns {string} обновлённый HTML
+ */
+function transformDemoHtml(html, data) {
+  const { document } = parseHTML(html)
+
+  if (document.querySelector('.demo-frame-footer')) {
+    return document.toString()
+  }
+
+  const styleLink = document.createElement('link')
+  styleLink.setAttribute('rel', 'stylesheet')
+  styleLink.setAttribute('href', '/styles/demo-frame.css')
+  document.head.appendChild(styleLink)
+
+  // Без defer/async: класс должен выставиться до первой отрисовки,
+  // иначе в отдельной вкладке будет видна вспышка шапки/футера.
+  const script = document.createElement('script')
+  script.setAttribute('src', '/scripts/demo-frame.js')
+  document.head.insertBefore(script, document.head.firstChild)
+
+  const existingStyle = document.body.getAttribute('style') || ''
+  const separator = existingStyle && !existingStyle.trim().endsWith(';') ? ';' : ''
+  document.body.setAttribute('style', `${existingStyle}${separator}--demo-frame-accent: ${data.accent}`)
+
+  const logo = document.createElement('a')
+  logo.setAttribute('class', 'demo-frame-logo')
+  logo.setAttribute('href', 'https://doka.guide/')
+  logo.textContent = 'U•ᴥ•U Дока'
+  document.body.appendChild(logo)
+
+  const footer = document.createElement('footer')
+  footer.setAttribute('class', 'demo-frame-footer')
+  footer.innerHTML = `
+    <a href="https://doka.guide/${data.section}/${data.slug}/">${data.slug} — Дока</a>
+    <a href="https://doka.guide/people/${data.authorUsername}/">${data.authorName}</a>
+  `
+  document.body.appendChild(footer)
+
+  return document.toString()
+}
+
+module.exports = { transformDemoHtml }

--- a/src/scripts/demo-frame.js
+++ b/src/scripts/demo-frame.js
@@ -1,0 +1,6 @@
+// Показывает шапку/подвал демки, только когда документ открыт не в iframe.
+// Класс выставляется синхронно (скрипт без defer/async), чтобы не было
+// вспышки шапки при первой отрисовке отдельной вкладки.
+if (window.self === window.top) {
+  document.documentElement.classList.add('demo-frame--visible')
+}

--- a/src/styles/demo-frame.css
+++ b/src/styles/demo-frame.css
@@ -1,0 +1,48 @@
+/* Автоматические шапка (лого) и подвал (ссылки на статью и автора) для демок,
+  когда демка открыта отдельно от статьи, а не внутри iframe.
+  Подключается и заполняется данными на этапе сборки — см. src/libs/demo-frame/. */
+
+.demo-frame-logo {
+  display: none;
+  position: fixed;
+  top: 12px;
+  left: 16px;
+  color: #FFF;
+  font-size: 13px;
+  text-decoration: none;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+
+.demo-frame-logo:hover {
+  opacity: 1;
+}
+
+.demo-frame-footer {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 8px 20px;
+  border-top: 2px solid var(--demo-frame-accent, hsl(0 0% 100%));
+  background-color: #18191C;
+  font-size: 13px;
+  font-style: italic;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.demo-frame-footer a {
+  color: inherit;
+  text-decoration-color: var(--demo-frame-accent, hsl(0 0% 100%));
+  text-decoration-thickness: 2px;
+}
+
+.demo-frame--visible .demo-frame-logo {
+  display: block;
+}
+
+.demo-frame--visible .demo-frame-footer {
+  display: flex;
+}


### PR DESCRIPTION
Demo-файлы уже открываются отдельно от статьи («Открыть демо в новой вкладке»). Теперь при таком открытии автоматически показываются лого и футер со ссылкой на статью и автора — без разметки в самой демке и без `?embed=1`.

Изменения:
- Шапка (лого) и футер (ссылка на статью и на автора) теперь подставляются автоматически на этапе сборки (`gulpfile.js`, `src/libs/demo-frame/`), без правок в самой демке
- Видимость определяется через `window.self === window.top`, `?embed=1` для этого больше не нужен
- Цвет акцента в футере берётся из `config/category-colors.js` по разделу статьи
- Общие `demo-frame.css`/`demo-frame.js` хэшируются и кэш-бастятся тем же механизмом, что и остальные ассеты сайта

Как проверить:
1. `npm run build` или `npm run preview`
2. Открыть любую демку напрямую, например `dist/css/hover/demos/link-hover/index.html` через локальный статический сервер (не `file://`, иначе `/styles/...` не резолвится) — снизу должен появиться футер со ссылкой на статью и автора, акцент — цвет раздела
3. Открыть статью с этой демкой в iframe (`dist/css/hover/index.html`) — внутри iframe шапки и футера быть не должно
4. `npm test` — новые тесты в `src/libs/__tests__/demo-frame.js`

Отдельно: 28 демок (11 статей), где уже были ручные `.demo-logo`/`.demo-meta`/`?embed=1`, временно будут показывать шапку/футер дважды — это отдельная задача по чистке контент-репо, не входит в этот PR