### PR TITLE
Update Baseline link to new URL

### DIFF
--- a/src/includes/blocks/baseline.njk
+++ b/src/includes/blocks/baseline.njk
@@ -23,5 +23,5 @@
       </li>
     {% endfor %}
   </ul>
-  <a class="wdi-browser-compat__link" href="https://web.dev/baseline/" target="_blank">О Baseline</a>
+  <a class="wdi-browser-compat__link" href="https://web-platform-dx.github.io/baseline/" target="_blank">О Baseline</a>
 </div>


### PR DESCRIPTION
Baseline is owned by the W3C WebDX Community Group. The current link goes to a web.dev URL (Google owned). The new link goes to the WebDX's Baseline home page.