### PR TITLE
Расширяет проверку линтерами в CI на весь код

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  js:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Загрузка платформы
@@ -15,31 +15,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Установка необходимых зависимостей
-        run: npm install --save-dev eslint-config-prettier eslint-plugin-prettier prettier
+          cache: npm
+      - name: Установка зависимостей
+        run: npm ci
 
-      - name: Проверка линтером JS
-        run: npx eslint '*.js'
-  css:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Загрузка платформы
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - name: Кэширование модулей
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Установка необходимых зависимостей
-        run:  npm install --save-dev stylelint-config-standard
+      # Шаги не прерывают друг друга: при падении видно все три отчёта сразу,
+      # а не только первый упавший линтер.
+      - name: Проверка editorconfig
+        if: ${{ !cancelled() }}
+        run: npm run editorconfig
       - name: Проверка линтером CSS
-        run: npx stylelint 'src/styles/**/*.css'
+        if: ${{ !cancelled() }}
+        run: npm run stylelint
+      - name: Проверка линтером JS
+        if: ${{ !cancelled() }}
+        run: npm run eslint


### PR DESCRIPTION
Второй из двух пулреквестов. Базируется на doka-guide/platform#1358 — GitHub перенацелит его на `main` автоматически, когда тот вольют.

## Почему линтеры не ловили ошибки

Триггеры у воркфлоу правильные, дело в самой проверке:

```yaml
run: npx eslint '*.js'    # было
```

Glob **без `**`** — это только корень репозитория. Фактически 4 файла: `gulpfile.js`, `jest.config.js`, `jest.setup.js`, `make-links.js`. Даже `.eleventy.js` мимо, потому что glob не берёт файлы с точки.

Локальный `npm run eslint` использует `'**/*.js'` и покрывает **109 файлов**.

> CI проверял 4 файла из 109. Всё содержимое `src/` не линтилось никогда — и все 11 файлов с накопленным долгом лежали именно там.

| Проверка | Было в CI |
|---|---|
| eslint | 4 файла из 109 |
| stylelint | нормально |
| editorconfig | отсутствовал во всех воркфлоу |

Отдельно: зависимости ставились как `npm install --save-dev prettier eslint-config-prettier eslint-plugin-prettier` — то есть **latest**, в обход `package-lock.json`. Версия линтера плавала от запуска к запуску, и мажор prettier мог покрасить CI без единого изменения в коде.

## Что изменилось

- CI вызывает те же npm-скрипты, что и разработчик локально — один источник правды вместо двух расходящихся глобов;
- добавлен шаг `editorconfig`;
- `npm ci` вместо `npm install --save-dev`, плюс кеш через `setup-node`;
- шаги идут через `if: !cancelled()` — в логе видно все три отчёта сразу. Это чинит ту же ловушку, из-за которой локальный `lint-check` со своим `&&` маскировал два линтера за первым.

## На что обратить внимание

**Открытые пулреквесты могут покраснеть.** Это первый честный прогон линтеров за долгое время: ветки, отведённые раньше, могут принести свои ошибки. После doka-guide/platform#1358 `main` чистый, чинится через `npx eslint --fix <файлы>`.

## Осталось за кадром

`npm test` не вызывается **ни в одном** воркфлоу — тесты живут только локально, в pre-commit их тоже нет. Не стал добавлять сюда: воркфлоу называется Linting и на его бейдж ссылается README. Могу сделать отдельным пулреквестом, если считаете нужным.

🤖 Generated with [Claude Code](https://claude.com/claude-code)