### PR TITLE
Не даёт неполному артефакту стереть боевой сайт

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -95,6 +95,19 @@ jobs:
       # Один tar вместо десятков тысяч файлов: иначе выгрузка дольше сборки.
       - name: Упаковка сайта
         run: tar --create --file site.tar --directory dist .
+      # Опись едет вместе с архивом, чтобы принимающая сторона могла убедиться,
+      # что доехало ровно то же самое. Без неё обрезанный при передаче архив
+      # распакуется частично, пройдёт проверку на index.html и уедет в rsync
+      # с --delete, который вычистит недостающее с боевого сайта.
+      - name: Опись артефакта
+        run: |
+          set -eu
+          {
+            printf 'sha256=%s\n' "$(sha256sum site.tar | cut -d' ' -f1)"
+            printf 'files=%s\n' "$(find dist -type f | wc -l | tr -d ' ')"
+            printf 'html=%s\n' "$(find dist -type f -name '*.html' | wc -l | tr -d ' ')"
+          } > site-manifest.txt
+          cat site-manifest.txt
       - name: Упаковка страниц
         run: |
           set -eu
@@ -105,7 +118,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: site-dist
-          path: site.tar
+          path: |
+            site.tar
+            site-manifest.txt
           retention-days: 1
           if-no-files-found: error
           # Из 494 МБ около 340 МБ — уже сжатые картинки, но 86 МБ HTML жмутся

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -116,6 +116,20 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: site-dist
+      # Опись защищает от обрезанного при передаче архива: дальше идёт rsync с
+      # --delete, и неполный артефакт стёр бы недостающее из превью.
+      # Разбираем grep-ом, а не source: опись собрана кодом из форка, это данные.
+      - name: Проверка артефакта
+        run: |
+          set -eu
+          test -f site-manifest.txt || { echo "В артефакте нет описи"; exit 1; }
+          EXPECTED_SHA="$(grep '^sha256=' site-manifest.txt | cut -d= -f2)"
+          ACTUAL_SHA="$(sha256sum site.tar | cut -d' ' -f1)"
+          if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+            echo "Архив побился при передаче: ждали $EXPECTED_SHA, получили $ACTUAL_SHA"
+            exit 1
+          fi
+          echo "EXPECTED_FILES=$(grep '^files=' site-manifest.txt | cut -d= -f2)" >> "$GITHUB_ENV"
       # Содержимое архива собрано кодом из форка. Распаковываем до записи ключа и
       # вычищаем симлинки: иначе член архива может указать на
       # $HOME/.ssh/doka_deploy и ключ утечёт в публичное превью.
@@ -125,6 +139,13 @@ jobs:
           set -eu
           PREVIEW_DIR="$(mktemp -d "$RUNNER_TEMP/preview.XXXXXX")"
           tar --extract --file site.tar --directory "$PREVIEW_DIR" --no-same-owner --no-same-permissions
+          ACTUAL_FILES="$(find "$PREVIEW_DIR" -type f | wc -l | tr -d ' ')"
+          if [ "$ACTUAL_FILES" -ne "$EXPECTED_FILES" ]; then
+            echo "Распаковалось $ACTUAL_FILES файлов вместо $EXPECTED_FILES"
+            exit 1
+          fi
+          # Симлинки вычищаем после сверки: их удаление не меняет число обычных
+          # файлов, но должно случиться до записи ключа.
           find "$PREVIEW_DIR" -type l -delete
           test -f "$PREVIEW_DIR/index.html" || { echo "В артефакте нет index.html"; exit 1; }
           echo "PREVIEW_DIR=$PREVIEW_DIR" >> "$GITHUB_ENV"

--- a/.github/workflows/product-deploy.yml
+++ b/.github/workflows/product-deploy.yml
@@ -75,12 +75,40 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: site-dist
+      # Дальше идёт rsync с --delete, поэтому неполный артефакт опаснее
+      # упавшего деплоя: он не оставит старую версию, а сотрёт недостающее.
+      # Проверяем контрольную сумму до распаковки и опись после, чтобы до
+      # сервера не доехал обрезанный или пустой архив.
+      - name: Проверка артефакта
+        run: |
+          set -eu
+          test -f site-manifest.txt || { echo "В артефакте нет описи"; exit 1; }
+          # Разбираем grep-ом, а не source: опись — данные, а не код.
+          EXPECTED_SHA="$(grep '^sha256=' site-manifest.txt | cut -d= -f2)"
+          ACTUAL_SHA="$(sha256sum site.tar | cut -d' ' -f1)"
+          if [ "$EXPECTED_SHA" != "$ACTUAL_SHA" ]; then
+            echo "Архив побился при передаче: ждали $EXPECTED_SHA, получили $ACTUAL_SHA"
+            exit 1
+          fi
+          echo "EXPECTED_FILES=$(grep '^files=' site-manifest.txt | cut -d= -f2)" >> "$GITHUB_ENV"
+          echo "EXPECTED_HTML=$(grep '^html=' site-manifest.txt | cut -d= -f2)" >> "$GITHUB_ENV"
       - name: Распаковка артефакта
         run: |
           set -eu
           SITE_DIR="$(mktemp -d "$RUNNER_TEMP/site.XXXXXX")"
           tar --extract --file site.tar --directory "$SITE_DIR" --no-same-owner --no-same-permissions
           test -f "$SITE_DIR/index.html" || { echo "В артефакте нет index.html"; exit 1; }
+          ACTUAL_FILES="$(find "$SITE_DIR" -type f | wc -l | tr -d ' ')"
+          if [ "$ACTUAL_FILES" -ne "$EXPECTED_FILES" ]; then
+            echo "Распаковалось $ACTUAL_FILES файлов вместо $EXPECTED_FILES"
+            exit 1
+          fi
+          # Нижняя граница на случай сборки, которая формально удалась, но выдала
+          # почти пустой dist. Сейчас страниц около 3500, запас многократный.
+          if [ "$EXPECTED_HTML" -lt 1000 ]; then
+            echo "Подозрительно мало страниц: $EXPECTED_HTML"
+            exit 1
+          fi
           echo "SITE_DIR=$SITE_DIR" >> "$GITHUB_ENV"
       # Последовательность та же, что и до выноса сборки: ключ, конфиг и
       # холостое подключение, которое добавляет хост в known_hosts.
@@ -96,10 +124,14 @@ jobs:
           printf '%s\n' "$DEPLOY_CONFIG" > "$HOME/.ssh/config"
           chmod 600 "$HOME/.ssh/config"
           ssh -o StrictHostKeyChecking=no deploy@dev.doka.guide
+      # --max-delete — последний предохранитель уже на уровне rsync: если что-то
+      # всё-таки прошло проверки и удаляемого оказалось неправдоподобно много,
+      # rsync прервётся с кодом 25 и не станет вычищать боевой сайт.
+      # Штатная выкатка удаляет единицы файлов — в основном старые кеш-хэши.
       - name: Публикация сайта
         run: |
           set -eu
           cd "$SITE_DIR"
           rsync --exclude 'api.json' --exclude 'mail' \
-            --archive --progress --compress --delete \
+            --archive --progress --compress --delete --max-delete=500 \
             . dev.doka.guide:/web/sites/doka.guide/www/


### PR DESCRIPTION
## Проблема

Публикация идёт через `rsync --delete`. Это было и до #1362, но переезд на артефакты добавил новый способ отказа: `tar` → выгрузка → загрузка → распаковка. Если архив приедет обрезанным, он распакуется частично, пройдёт единственную имеющуюся проверку `test -f index.html` — и `--delete` вычистит с боевого сайта всё, чего в нём не хватает.

То есть неполный артефакт был **опаснее упавшего деплоя**: упавший оставляет старую версию, а этот её разрушает. Так быть не должно — при любой ошибке должна оставаться предыдущая версия.

## Что сделано

**Опись рядом с архивом.** Сборка кладёт `site-manifest.txt` с `sha256` архива, числом файлов и числом страниц.

**Две проверки на приёме.** Контрольная сумма сверяется до распаковки, количество файлов — после. Плюс нижняя граница: сборка, которая формально удалась, но выдала меньше тысячи страниц вместо примерно трёх с половиной тысяч, до сервера не доедет.

**`--max-delete=500` на самом rsync.** Последний предохранитель, если что-то всё же прошло проверки: rsync прервётся с кодом 25 вместо того, чтобы вычищать сайт. Штатная выкатка удаляет единицы файлов, в основном старые кеш-хэши, так что запас огромный.

Те же проверки добавлены в превью — там `--delete` тоже есть, просто цена ошибки ниже.

## Проверено

Логика прогнана локально на трёх сценариях:

| Сценарий | Результат |
|---|---|
| целый архив | пропущен |
| обрезан на 60 % | отбит по контрольной сумме |
| валидный архив, но почти пустой `dist` | отбит по нижней границе числа страниц |

## Чего это всё ещё не даёт

Честная оговорка: это защита от **неполного артефакта**, а не полная атомарность. Если rsync упадёт в середине уже начатой передачи, сайт останется в смешанном состоянии — часть файлов новая, часть старая. Гарантию «при ошибке просто остаётся старая версия» даёт только выкатка в новую директорию с атомарным переключением симлинка:

```
/web/sites/doka.guide/releases/<sha>/   <- rsync сюда
/web/sites/doka.guide/www -> releases/<sha>   <- ln -sfn, атомарно
```

Это требует изменения раскладки на сервере и правки конфига веб-сервера, поэтому отдельным решением — скажи, если делаем.

## Замечание про `source`

Опись разбирается `grep`-ом, а не `source`. В превью её собирает код из форка: это данные, и исполнять их нельзя.
