### PR TITLE
Убирает пустые строки в выдаче поиска

### DIFF
--- a/src/scripts/core/__tests__/search-commons-test.js
+++ b/src/scripts/core/__tests__/search-commons-test.js
@@ -1,0 +1,46 @@
+const { processHits } = require('../search-commons.js')
+
+const hitsTemplate = [
+  {
+    title: '`&lt;<mark>html</mark>&gt;`',
+    link: '/html/html/',
+    category: 'html',
+    tags: ['doka'],
+    fragments: ['фрагмент'],
+  },
+  { title: '', link: '/css/', category: 'css', tags: [] },
+  { title: '   ', link: '/html/', category: 'html', tags: [] },
+  { title: 'Глобальные атрибуты', link: '/html/global-attrs/', category: 'html', tags: ['doka'] },
+]
+
+describe('processHits', () => {
+  it('возвращает пустой массив, если ответа нет', () => {
+    expect(processHits(undefined)).toEqual([])
+  })
+
+  it('выбрасывает результаты без заголовка — индексы разделов', () => {
+    const result = processHits(hitsTemplate)
+
+    expect(result).toHaveLength(2)
+    expect(result.map((hit) => hit.url)).toEqual(['/html/html/', '/html/global-attrs/'])
+  })
+
+  it('раскладывает поля статьи', () => {
+    const [hit] = processHits(hitsTemplate)
+
+    expect(hit).toEqual({
+      originalTitle: '`&lt;<mark>html</mark>&gt;`',
+      title: '`&lt;<mark>html</mark>&gt;`',
+      summary: ['фрагмент'],
+      url: '/html/html/',
+      category: 'html',
+      tags: ['doka'],
+    })
+  })
+
+  it('подставляет пустой список фрагментов, если их нет', () => {
+    const [, hit] = processHits(hitsTemplate)
+
+    expect(hit.summary).toEqual([])
+  })
+})

--- a/src/scripts/core/search-commons.js
+++ b/src/scripts/core/search-commons.js
@@ -57,16 +57,20 @@ export const SEARCHABLE_SHORT_WORDS = new Set([
 
 export function processHits(searchObject) {
   if (searchObject) {
-    return searchObject.map((articleObject) => {
-      return {
-        originalTitle: articleObject.title,
-        title: articleObject.title,
-        summary: articleObject.fragments ? articleObject.fragments : [],
-        url: `${articleObject.link}`,
-        category: articleObject.category,
-        tags: articleObject.tags,
-      }
-    })
+    // поиск отдаёт и индексы разделов (/css/, /html/) — у них нет заголовка,
+    // в выдаче они превращаются в пустые строки
+    return searchObject
+      .filter((articleObject) => articleObject.title && articleObject.title.trim() !== '')
+      .map((articleObject) => {
+        return {
+          originalTitle: articleObject.title,
+          title: articleObject.title,
+          summary: articleObject.fragments ? articleObject.fragments : [],
+          url: `${articleObject.link}`,
+          category: articleObject.category,
+          tags: articleObject.tags,
+        }
+      })
   } else {
     return []
   }


### PR DESCRIPTION
## Проблема

В выдаче поиска появились пустые строки — и в быстром поиске в шапке, и на странице `/search/`.

Причина не в вёрстке: `search.doka.guide` возвращает не только статьи, но и индексы разделов, а у них пустой `title`. На запрос `html` приходит 17 результатов, два из них такие:

```
 9 "Вставка изображений в <mark>HTML</mark>"  html  /html/images-paste-methods/
10 ""                                         css   /css/
11 "`&lt;!DOCTYPE&gt;`"                        html  /html/doctype/
12 "`.outer<mark>HTML</mark>`"                 js    /js/element-outerhtml/
13 ""                                         html  /html/
14 "`:root`"                                  css   /css/root/
```

Клиент рисовал их как обычные пункты. Пустая ссылка с паддингом даёт пустую строку, а при наведении у неё подсвечивается `--accent-color` — это та самая цветная полоса без текста. На странице поиска то же самое превращалось в блок `search-hit` с пустым заголовком.

## Что сделано

`processHits` отбрасывает результаты без заголовка. Функция общая для `quick-search` и страницы поиска, так что чинятся оба места одной правкой.

```js
return searchObject
  .filter((articleObject) => articleObject.title && articleObject.title.trim() !== '')
  .map((articleObject) => { … })
```

Плюс первые тесты на `search-commons.js`: разбор полей, пустой ответ, отсутствующие `fragments` и собственно отсев результатов без заголовка.

## Что это не чинит

Индексы разделов вообще не должны попадать в поисковый индекс — это правится в [`doka-guide/search`](https://github.com/doka-guide/search). Здесь закрыт симптом: даже если в индекс попадёт что-то ещё без заголовка, в выдаче оно не появится. Но источник мусора остаётся, и по-хорошему его стоит убрать на стороне поиска.

## Как проверено

Node v24.20.0, ветка отведена от `main` после #1364.

- `npm test` — 19 из 20 зелёные, включая 4 новых
- `npx eslint`, `npx prettier --check`, `npm run editorconfig` по изменённым файлам — чисто
- ответ API снят живьём с `search.doka.guide` по запросам из скриншота

Падающий тест — `last-update-test.js:48`, ждёт «2 часа назад» на 7000 секундах и получает «1 час назад». Он падает и на чистом `main` без этих правок, к поиску отношения не имеет. В CI его не видно, потому что `npm test` не вызывает ни один воркфлоу — та же история, что описана в #1359 и #1361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
