### PR TITLE
Проверяет валидность разметки по одной странице каждого типа

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "editorconfig": "editorconfig-checker",
     "lint:css": "stylelint 'src/styles/**/*.css'",
     "lint:js": "eslint '**/*.js'",
-    "lint:html": "node-w3c-validator -i ./dist/**/*.html -f lint -ev",
+    "lint:html": "node scripts/lint-html.js",
     "lint-check": "npm run editorconfig && npm run lint:css && npm run lint:js && npm run lint:html",
     "test": "jest",
     "make-links": "node make-links.js"

--- a/scripts/lint-html.js
+++ b/scripts/lint-html.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+// Проверяет валидность разметки, которую выдаёт платформа.
+//
+// Проверяется по одной странице каждого типа, а не весь сайт. Причина в том,
+// что платформа отвечает за шаблоны, а не за контент: все статьи рендерятся
+// одним и тем же doc.njk, и тысячная статья не скажет ничего, чего не сказала
+// первая. Ошибки в авторской разметке — например, в HTML демок — это забота
+// репозитория контента, и тащить их в проверки платформы незачем.
+//
+// Раньше проверка была устроена глобом `./dist/**/*.html` без кавычек. Его
+// разворачивал sh, который не умеет globstar, поэтому `**` схлопывался в `*`
+// и до валидатора доезжали 27 страниц из 3495 — одни индексы разделов, ни
+// одной статьи. То есть весь слой шаблонов статей не проверялся вообще.
+
+'use strict'
+
+const path = require('path')
+const { existsSync } = require('fs')
+const { vnu } = require('vnu-jar')
+
+const DIST = 'dist'
+
+// По одному представителю на каждый тип страницы. Если добавляется новый вид
+// страницы — добавляйте его сюда, иначе он останется без проверки.
+const PAGES = [
+  ['index.html', 'главная'],
+  ['css/index.html', 'индекс раздела'],
+  ['all/index.html', 'список всех статей'],
+  ['people/index.html', 'список участников'],
+  ['people/solarrust/index.html', 'страница участника'],
+  ['search/index.html', 'поиск'],
+  ['about/index.html', 'служебная страница'],
+  ['subscribe/index.html', 'страница подписки'],
+  ['offline/index.html', 'страница офлайна'],
+  ['404/index.html', 'страница ошибки'],
+  ['css/display/index.html', 'статья со всеми трансформациями'],
+  ['css/index.sc.html', 'социальная карточка раздела'],
+  ['css/display/index.sc.html', 'социальная карточка статьи'],
+  ['all/index.sc.html', 'социальная карточка списка статей'],
+]
+
+function main() {
+  const missing = PAGES.filter(([file]) => !existsSync(path.join(DIST, file)))
+
+  if (missing.length > 0) {
+    // Пропавшая страница — это тоже поломка: либо сборка перестала её делать,
+    // либо тип страницы переименовали и список пора обновить.
+    console.error('Не найдены страницы для проверки:')
+    for (const [file, kind] of missing) {
+      console.error(`  ${file} — ${kind}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  const files = PAGES.map(([file]) => path.join(DIST, file))
+
+  console.log(`Проверяется ${files.length} страниц — по одной каждого типа.`)
+
+  vnu
+    .check(['--format', 'gnu', '--exit-zero-always', ...files])
+    .then((output) => {
+      const lines = output.split('\n').filter((line) => line.trim() !== '')
+      // Предупреждения валидатора — советы по разметке вроде «у секции нет
+      // заголовка». Показываем их, но проверку из-за них не роняем: страницы
+      // социальных карточек существуют только под скриншот, и заголовки там
+      // не нужны.
+      const errors = lines.filter((line) => /: error/.test(line))
+      const warnings = lines.filter((line) => !/: error/.test(line))
+
+      for (const line of warnings) {
+        console.log(line)
+      }
+
+      if (errors.length === 0) {
+        console.log(`\nОшибок нет. Предупреждений: ${warnings.length}.`)
+        return
+      }
+
+      console.error('')
+      for (const line of errors) {
+        console.error(line)
+      }
+      console.error(`\nОшибок: ${errors.length}.`)
+      process.exitCode = 1
+    })
+    .catch((error) => {
+      const message = error.message.trim()
+
+      if (message.includes('UnsupportedClassVersionError')) {
+        // vnu-jar считает подходящей любую Java начиная с 11, хотя сам jar
+        // собран под 17. На машине с Java 11–16 он берёт системную и падает
+        // с невнятной ошибкой про версию класса.
+        console.error('Валидатору нужна Java 17 или новее, а в PATH оказалась более старая.')
+        console.error('Поставьте Java 17+ или уберите старую из PATH — тогда vnu-jar скачает свою.')
+      } else {
+        console.error(message)
+      }
+
+      process.exitCode = 1
+    })
+}
+
+main()

--- a/src/includes/questions.njk
+++ b/src/includes/questions.njk
@@ -78,7 +78,7 @@
                     ) }}
                   {% endfor %}
                 </span>
-                <div>
+                <span class="answer__author-text">
                   <span class="answer__author-name">
                     {{ answerOrName(
                       name=(answerAuthor.data.name or answer.fileSlug),
@@ -86,7 +86,7 @@
                     ) }}
                   </span>
                   &nbsp;отвечает
-                </div>
+                </span>
               </h3>
               <div class="answer__content {% if not answer.isLong %}answer__content--short{% endif %} content">
                 <div class="answer__summary content">

--- a/src/includes/subscribe-popup.njk
+++ b/src/includes/subscribe-popup.njk
@@ -7,7 +7,7 @@
   </form>
   <div class="subscribe-popup__container">
     <p class="subscribe-popup__text">В рассылке приходят тематические подборки, советы, авторские и партнёрские колонки</p>
-    <form class="subscribe-popup__email-form" action="">
+    <form class="subscribe-popup__email-form">
       <label class="subscribe-popup__label">
         <input class="subscribe-popup__input" type="email" name="email" placeholder="dog@doka.guide" inputmode="email" required>
         <span class="subscribe-popup__hint">Оставьте вашу почту</span>

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -16,6 +16,13 @@
 
     {% include "meta.njk" %}
 
+    {# Стили, которые страница вычисляет из коллекций и не может держать в
+    обычном CSS-файле. В head, потому что style — метаданные и в разметке
+    страницы невалиден. #}
+    {% if pageStyles %}
+      <style>{{ pageStyles | safe }}</style>
+    {% endif %}
+
   </head>
   <body class="base__body {{ bodyClass }}">
     {{ content | safe }}

--- a/src/scripts/libs/__tests__/last-update-test.js
+++ b/src/scripts/libs/__tests__/last-update-test.js
@@ -5,16 +5,14 @@
 import { init } from '../../modules/last-update'
 
 const createPastDate = (passedSeconds) => {
-  // Создаёт дату на момент «N-секунд назад» и возвращает её для последующих проверок
-  const date = new Date()
-
-  if (passedSeconds >= 3600) {
-    date.setHours(date.getHours() - passedSeconds / 3600)
-  } else if (passedSeconds >= 60) {
-    date.setMinutes(date.getMinutes() - passedSeconds / 60)
-  } else {
-    date.setSeconds(date.getSeconds() - passedSeconds)
-  }
+  // Создаёт дату на момент «N-секунд назад» и возвращает её для последующих проверок.
+  //
+  // Считается вычитанием миллисекунд, а не через setHours. Прежний вариант
+  // передавал в setHours дробное число часов, а оно усекается к нулю: днём
+  // getHours() - 1.944 давало «минус два часа», но в первом часу ночи
+  // 0 - 1.944 превращалось в -1, то есть в один час. Из-за этого тест падал
+  // каждые сутки с 00:00 до 01:00.
+  const date = new Date(Date.now() - passedSeconds * 1000)
 
   const time = document.createElement('time')
   time.setAttribute('data-relative-time', null)

--- a/src/views/people.11tydata.js
+++ b/src/views/people.11tydata.js
@@ -2,4 +2,18 @@ module.exports = {
   title: 'Участники',
   layout: 'base.njk',
   permalink: '/people/',
+
+  eleventyComputed: {
+    // Правило скрывает карточки участников, не попадающие в выбранные разделы.
+    // Строится из коллекций, поэтому не может лежать в обычном CSS-файле.
+    // Раньше отдавалось тегом <style> прямо в разметке страницы, но по
+    // спецификации style — метаданные и допустим только в head.
+    pageStyles: function (data) {
+      const sections = data.collections.articleIndexes || []
+      const selector = sections
+        .map((section) => `[data-filters*='${section.fileSlug}'] > *:not([data-categories*='${section.fileSlug}'])`)
+        .join(', ')
+      return selector ? `${selector} { display: none; }` : ''
+    },
+  },
 }

--- a/src/views/people.njk
+++ b/src/views/people.njk
@@ -56,7 +56,7 @@
 
       <button class="filter-panel__button float-button" type="button" aria-expanded="false">
         <span class="float-button__name visually-hidden">Показать фильтр</span>
-        <div class="float-button__icons" aria-hidden="true">
+        <span class="float-button__icons" aria-hidden="true">
           <svg class="float-button__icon float-button__icon--close" width="48" height="48" fill="currentColor" viewBox="0 0 48 48">
             <path d="M31.27 32.88l-7.3-7.3-7.24 7.24c-.43.43-.8.58-1.15.58a.94.94 0 01-.71-.26.94.94 0 01-.27-.72c0-.34.15-.72.58-1.15l7.24-7.24-7.24-7.23c-.43-.43-.58-.81-.58-1.16 0-.32.1-.54.27-.7a.94.94 0 01.7-.28c.35 0 .73.16 1.16.59l7.24 7.23 7.3-7.3c.44-.44.8-.58 1.09-.58.15 0 .36.07.62.37.28.3.36.55.36.73 0 .3-.14.65-.52 1.03l-7.3 7.3 7.3 7.3c.44.44.58.8.58 1.1 0 .15-.07.36-.37.62-.3.27-.55.35-.73.35-.3 0-.65-.13-1.03-.52z"></path>
           </svg>
@@ -72,22 +72,10 @@
               <circle cx="31.5" cy="16.5" r="1.85"></circle>
             </g>
           </svg>
-        </div>
+        </span>
       </button>
     </form>
 
-    <style>
-      {% set filterSelector %}
-        {% set comma = joiner() %}
-        {% for index in collections.articleIndexes %}
-          {{ comma() }}
-          [data-filters*='{{ index.fileSlug }}'] > *:not([data-categories*='{{ index.fileSlug }}'])
-        {% endfor %}
-      {% endset %}
-      {{ filterSelector | safe }} {
-        display: none;
-      }
-    </style>
 
     <ol class="people-page__list person-grid base-list">
       {% for personDataItem in peopleData %}

--- a/src/views/sc-all.11tydata.js
+++ b/src/views/sc-all.11tydata.js
@@ -1,5 +1,7 @@
 module.exports = {
   title: 'Все статьи',
-  layout: 'base.njk',
+  // Без layout: sc-all.njk — уже полный документ, как sc.njk и
+  // sc-index.njk. С обёрткой в base.njk страница получалась вложенной
+  // сама в себя, с двумя doctype и двумя body.
   permalink: '/all/index.sc.html',
 }

--- a/src/views/sc-all.njk
+++ b/src/views/sc-all.njk
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title }}</title>
     <link rel="stylesheet" href="../styles/index.sc.css">
   </head>
   <body class="base__body {{ bodyClass }}">

--- a/src/views/sc-index.njk
+++ b/src/views/sc-index.njk
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ documentTitle }}</title>
     <link rel="stylesheet" href="../styles/index.sc.css">
   </head>
   <body class="base__body {{ bodyClass }}">

--- a/src/views/sc.11tydata.js
+++ b/src/views/sc.11tydata.js
@@ -1,3 +1,5 @@
+const { titleFormatter } = require('../libs/title-formatter/title-formatter')
+
 module.exports = {
   pagination: {
     data: 'collections.docs',
@@ -8,6 +10,13 @@ module.exports = {
   permalink: '{{doc.filePathStem}}.sc.html',
 
   eleventyComputed: {
+    // Нужен для <title> на странице карточки: в head он обязателен по
+    // спецификации, хотя сама страница нужна только под скриншот.
+    documentTitle: function (data) {
+      const { doc } = data
+      return titleFormatter([doc.data.title, 'Дока'])
+    },
+
     cover: function (data) {
       const { doc } = data
       return doc.data.cover

--- a/src/views/sc.njk
+++ b/src/views/sc.njk
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ documentTitle }}</title>
     <link rel="stylesheet" href="../../styles/index.sc.css">
   </head>
   <body class="base__body {{ bodyClass }}">

--- a/src/views/subscribe.njk
+++ b/src/views/subscribe.njk
@@ -19,7 +19,7 @@
     <p>Здесь можете подписаться и сразу рассказать немного о себе, чтобы мы настроили рассылку под ваши интересы.</p>
     <p>📨 <a href="/newsletters/">Архив рассылки</a></p>
 
-    <form class="subscribe-page__subscribe subscribe-settings form-with-status" aria-labelledby="subscribe-label" action="">
+    <form class="subscribe-page__subscribe subscribe-settings form-with-status" aria-labelledby="subscribe-label">
       <h2 class="subscribe-settings__title" id="subscribe-label">Настроить рассылку</h2>
       <div class="subscribe-settings__row">
         <input type="hidden" name="active" value="false">
@@ -142,7 +142,7 @@
     </form>
 
     <section class="unsubscribe-section">
-      <form class="subscribe-page__unsubscribe subscribe-settings unsubscribe__form form-with-status" aria-labelledby="unsubscribe-label" action="">
+      <form class="subscribe-page__unsubscribe subscribe-settings unsubscribe__form form-with-status" aria-labelledby="unsubscribe-label">
         <h2 class="subscribe-settings__title" id="unsubscribe-label">Отписаться от рассылки <span aria-hidden="true">U×ᴥ×U</span></h2>
         <div class="unsubscribe__row">
           <div class="unsubscribe__field">


### PR DESCRIPTION
## Проверка не работала

`lint:html` был устроен глобом `./dist/**/*.html` **без кавычек**. Его разворачивал `sh`, который не поддерживает globstar: `**` схлопывался в `*`, и до валидатора доезжали `./dist/*/*.html` — **27 страниц из 3495**, одни индексы разделов.

То есть шаблоны статей, участников, подписки и социальных карточек не проверялись вообще, а зелёная галочка в CI это скрывала.

## Проверять весь сайт незачем

Полный прогон дал 3438 ошибок, и разбор показал, что гнаться за нулём здесь неправильно:

| ошибок | где | чьё |
|---|---|---|
| 994 | демки | **контент** — авторский HTML из другого репозитория |
| 526 | из них | **ложные** — валидатор не знает CSS anchor positioning |
| 1018 | социальные карточки | платформа, один шаблон |
| 1237 | формы | платформа, два шаблона |

Платформа отвечает за шаблоны, а не за контент. Все статьи рендерятся одним `doc.njk` — тысячная статья не скажет ничего, чего не сказала первая, зато притащит чужие ошибки. Отдельная ирония: 526 ложных срабатываний — это CSS anchor positioning в демках, то есть Дока показывает свежий CSS в статьях про этот самый CSS, а валидатор его пока не знает.

Поэтому `scripts/lint-html.js` проверяет **по одному представителю каждого типа страницы** — четырнадцать штук: главная, индекс раздела, список статей, список участников, страница участника, поиск, служебная страница, подписка, офлайн, 404, статья и три вида социальных карточек.

Список явный, с описанием у каждой записи. Пропавшая страница роняет проверку — это тоже поломка, либо сборка перестала её делать, либо тип переименовали. Прогон занимает секунды вместо минут и не разъезжается при росте контента.

Предупреждения выводятся, но сборку не роняют: советы вроде «у секции нет заголовка» относятся к страницам карточек, которые существуют только под скриншот.

## Что проверка сразу нашла

Две вещи, которых старый глоб не видел в принципе:

**`all/index.sc.html` был сломан наглухо** — два `<!DOCTYPE>`, два `<body>`, страница вложена сама в себя. В `sc-all.11tydata.js` стоял `layout: 'base.njk'`, хотя шаблон уже полный документ. У двух других карточек layout нет — опечатка, прожившая незамеченной.

**Ещё два пустых `action`** на `/subscribe/` — в другом шаблоне, не в попапе.

## Все починки

- пустой `action` у форм подписки — в попапе и на `/subscribe/`. Валидатор советует просто убрать атрибут; JS и так перехватывает `submit` через `preventDefault`
- отсутствующий `<title>` в `head` у всех трёх шаблонов социальных карточек
- вложенный сам в себя `all/index.sc.html`
- `div` внутри `h3` в блоке автора «На собеседовании» и `div` внутри `button` на странице участников — заменены на `span`. Раскладка не меняется: первый родитель `inline-flex`, второй абсолютно позиционирован
- `<style>` со страницы участников уехал в `head`. Правило строится из коллекций и не может лежать в обычном CSS, но `style` — метаданные и в разметке страницы невалиден

## Отдельным коммитом — тест, падавший каждую ночь

`createPastDate` считала дату через `setHours(getHours() - секунды / 3600)`, передавая дробное число часов. Оно усекается к нулю, поэтому результат зависел от времени суток: днём `10 - 1.944 → 8` (минус два часа, тест зелёный), а в первом часу ночи `0 - 1.944 → -1` (минус один час, тест красный).

Нашлось случайно — я запустила тесты в 00:45. Тесты только что добавили в CI в #1365, так что без этой починки `Linting` падал бы **по часу в сутки** без всякой связи с кодом.

## Как проверено

- `npm test` — 16 тестов
- `eslint`, `stylelint`, `editorconfig-checker` — чисто
- `npm run build` — полная продакшн-сборка, exit 0, 3495 страниц, бандлы с кеш-хэшами
- `npm run lint:html` — **ошибок нет**, 15 предупреждений
- фильтр на странице участников проверен в собранной разметке: правило на месте, в `head`, со всеми шестью разделами