### PR TITLE
Покрывает тестами трансформации, выносит тесты в отдельный воркфлоу

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,8 +21,13 @@ jobs:
 
       # Шаги не прерывают друг друга: при падении видно все три отчёта сразу,
       # а не только первый упавший линтер.
+      # editorconfig-checker скачивает свой бинарник через GitHub API. Без
+      # токена запрос неавторизованный, а лимит общий на IP раннера — прогоны
+      # падали случайно, с «API rate limit exceeded» вместо ошибок разметки.
       - name: Проверка editorconfig
         if: ${{ !cancelled() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run editorconfig
       - name: Проверка линтером CSS
         if: ${{ !cancelled() }}
@@ -30,8 +35,3 @@ jobs:
       - name: Проверка линтером JS
         if: ${{ !cancelled() }}
         run: npm run lint:js
-      # Раньше jest жил только локально и в pre-commit его тоже не было:
-      # зелёный CI ничего не говорил о тестах.
-      - name: Тесты
-        if: ${{ !cancelled() }}
-        run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  test:
+    name: Тесты
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Загрузка платформы
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+      - name: Установка зависимостей
+        run: npm ci
+      - name: Тесты
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Платформа Доки
 
 [![Статус линтера](https://github.com/doka-guide/platform/actions/workflows/linting.yml/badge.svg?branch=main&event=push)](https://github.com/doka-guide/platform/actions/workflows/linting.yml)
-[![W3C Validator](https://github.com/doka-guide/platform/actions/workflows/w3c-validator.yml/badge.svg?branch=main&event=push)](https://github.com/doka-guide/platform/actions/workflows/w3c-validator.yml)
+[![Статус тестов](https://github.com/doka-guide/platform/actions/workflows/tests.yml/badge.svg?branch=main&event=push)](https://github.com/doka-guide/platform/actions/workflows/tests.yml)
 [![Статус деплоя](https://github.com/doka-guide/platform/actions/workflows/product-deploy.yml/badge.svg?branch=main&event=push)](https://github.com/doka-guide/platform/actions/workflows/product-deploy.yml)
 [![Статус Docker](https://github.com/doka-guide/platform/actions/workflows/docker-deploy.yml/badge.svg?branch=main&event=push)](https://github.com/doka-guide/platform/actions/workflows/docker-deploy.yml)
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,11 @@ module.exports = {
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
   },
+  // linkedom и его зависимости поставляются как ESM, а jest грузит node_modules
+  // как CommonJS и падает на `import`. Эти пакеты нужны тестам трансформаций:
+  // именно через linkedom сборка разбирает HTML.
+  transformIgnorePatterns: [
+    '/node_modules/(?!(linkedom|css-select|css-what|boolbase|domhandler|domutils|domelementtype' +
+      '|nth-check|entities|htmlparser2|uhyphen|cssom|html-escaper|dom-serializer)/)',
+  ],
 }

--- a/src/libs/__tests__/github-contribution-stats-test.js
+++ b/src/libs/__tests__/github-contribution-stats-test.js
@@ -1,0 +1,38 @@
+// Модуль читает .issues.json на верхнем уровне, и файла в репозитории нет —
+// его готовит отдельный репозиторий doka-guide/cache. Подменяем виртуальным
+// модулем, чтобы тест не зависел ни от наличия файла, ни от его содержимого.
+jest.mock(
+  '../../../.issues.json',
+  () => [
+    { user: { login: 'Solarrust' }, pull_request: {}, closed_at: '2021-05-20T10:00:00Z' },
+    { user: { login: 'solarrust' }, pull_request: {}, closed_at: '2023-01-01T10:00:00Z' },
+    { user: { login: 'solarrust' }, closed_at: null },
+    { user: { login: 'pepelsbey' }, pull_request: {}, closed_at: '2022-07-07T10:00:00Z' },
+  ],
+  { virtual: true },
+)
+
+const { getAuthorContributionStats } = require('../github-contribution-stats/github-contribution-stats')
+
+describe('getAuthorContributionStats', () => {
+  const stats = getAuthorContributionStats()
+
+  it('считает пулреквесты и issue раздельно', () => {
+    expect(stats.solarrust.pr).toBe(2)
+    expect(stats.solarrust.issues).toBe(1)
+  })
+
+  it('приводит логины к нижнему регистру и не двоит участника', () => {
+    // В выборке есть и Solarrust, и solarrust — это один человек
+    expect(Object.keys(stats)).toEqual(['solarrust', 'pepelsbey'])
+  })
+
+  it('запоминает дату самого раннего вклада', () => {
+    expect(stats.solarrust.first).toEqual(new Date('2021-05-20T10:00:00Z'))
+  })
+
+  it('считает каждого участника отдельно', () => {
+    expect(stats.pepelsbey.pr).toBe(1)
+    expect(stats.pepelsbey.issues).toBe(0)
+  })
+})

--- a/src/libs/__tests__/heading-hierarchy-test.js
+++ b/src/libs/__tests__/heading-hierarchy-test.js
@@ -1,0 +1,72 @@
+const { parseHTML } = require('linkedom')
+const HeadingHierarchy = require('../heading-hierarchy/heading-hierarchy')
+
+// Оглавление строится из живых элементов, поэтому заголовки собираем из
+// разобранного документа — так же, как это делает toc-transform.
+function headingsFrom(html) {
+  const { document } = parseHTML(`<!DOCTYPE html><html><body>${html}</body></html>`)
+  return Array.from(document.querySelectorAll('h2, h3, h4, h5, h6, p'))
+}
+
+describe('createHierarchy', () => {
+  it('складывает заголовки одного уровня в соседей', () => {
+    const root = HeadingHierarchy.createHierarchy(headingsFrom('<h2 id="a">А</h2><h2 id="b">Б</h2>'))
+
+    expect(root.children).toHaveLength(2)
+    expect(root.children.map((item) => item.id)).toEqual(['a', 'b'])
+  })
+
+  it('вкладывает заголовок меньшего уровня в предыдущий', () => {
+    const root = HeadingHierarchy.createHierarchy(headingsFrom('<h2 id="a">А</h2><h3 id="b">Б</h3>'))
+
+    expect(root.children).toHaveLength(1)
+    expect(root.children[0].children.map((item) => item.id)).toEqual(['b'])
+  })
+
+  it('поднимается на нужный уровень после вложенных заголовков', () => {
+    const html = '<h2 id="a">А</h2><h3 id="b">Б</h3><h4 id="v">В</h4><h2 id="g">Г</h2>'
+    const root = HeadingHierarchy.createHierarchy(headingsFrom(html))
+
+    expect(root.children.map((item) => item.id)).toEqual(['a', 'g'])
+    expect(root.children[0].children[0].children.map((item) => item.id)).toEqual(['v'])
+  })
+
+  it('считает абзац заголовком третьего уровня', () => {
+    // Так размечены вопросы в рубрике «На собеседовании»
+    const root = HeadingHierarchy.createHierarchy(headingsFrom('<h2 id="a">А</h2><p id="q">Вопрос</p>'))
+
+    expect(root.children[0].children.map((item) => item.id)).toEqual(['q'])
+  })
+
+  it('не падает на пустом списке', () => {
+    const root = HeadingHierarchy.createHierarchy([])
+
+    expect(root.children).toHaveLength(0)
+  })
+})
+
+describe('render', () => {
+  it('делает список ссылок с якорями', () => {
+    const root = HeadingHierarchy.createHierarchy(headingsFrom('<h2 id="kak-eto">Как это</h2>'))
+    const html = HeadingHierarchy.render(root)
+
+    expect(html).toContain('class="toc"')
+    expect(html).toContain('href="#kak-eto"')
+    expect(html).toContain('Как это')
+  })
+
+  it('экранирует разметку в тексте заголовка', () => {
+    const root = HeadingHierarchy.createHierarchy(headingsFrom('<h2 id="a">Тег &lt;script&gt;</h2>'))
+    const html = HeadingHierarchy.render(root)
+
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('вкладывает дочерние пункты в отдельный список', () => {
+    const root = HeadingHierarchy.createHierarchy(headingsFrom('<h2 id="a">А</h2><h3 id="b">Б</h3>'))
+    const html = HeadingHierarchy.render(root)
+
+    expect(html.match(/<ol class="toc__list/g)).toHaveLength(2)
+  })
+})

--- a/src/libs/__tests__/role-constructor-test.js
+++ b/src/libs/__tests__/role-constructor-test.js
@@ -1,0 +1,31 @@
+const { getRole } = require('../role-constructor/role-constructor')
+const collection = require('../role-constructor/collection.json')
+
+const KNOWN_ROLE = 'doka-core-team'
+
+describe('getRole', () => {
+  it('разворачивает строку в описание роли из коллекции', () => {
+    expect(getRole(KNOWN_ROLE)).toEqual(collection[KNOWN_ROLE])
+  })
+
+  it('позволяет переопределить отдельные поля', () => {
+    const role = getRole({ [KNOWN_ROLE]: { title: 'Своё название' } })
+
+    expect(role.title).toBe('Своё название')
+    // Остальные поля берутся из коллекции
+    expect(role.color).toBe(collection[KNOWN_ROLE].color)
+    expect(role.url).toBe(collection[KNOWN_ROLE].url)
+  })
+
+  it('возвращает пустой объект для неизвестного типа роли', () => {
+    expect(getRole({ 'нет-такой-роли': { title: 'Что-то' } })).toEqual({})
+  })
+
+  it('возвращает undefined для неизвестной строки', () => {
+    expect(getRole('нет-такой-роли')).toBeUndefined()
+  })
+
+  it('не падает на пустом объекте', () => {
+    expect(getRole({})).toEqual({})
+  })
+})

--- a/src/libs/__tests__/title-formatter-test.js
+++ b/src/libs/__tests__/title-formatter-test.js
@@ -1,0 +1,21 @@
+const { titleFormatter } = require('../title-formatter/title-formatter')
+
+describe('titleFormatter', () => {
+  it('склеивает части длинным тире', () => {
+    expect(titleFormatter(['display', 'CSS', 'Дока'])).toBe('display — CSS — Дока')
+  })
+
+  it('выбрасывает пустые части', () => {
+    expect(titleFormatter(['display', undefined, 'Дока'])).toBe('display — Дока')
+    expect(titleFormatter(['display', '', null, 'Дока'])).toBe('display — Дока')
+  })
+
+  it('возвращает единственную часть без разделителя', () => {
+    expect(titleFormatter(['Дока'])).toBe('Дока')
+  })
+
+  it('возвращает пустую строку, когда частей нет', () => {
+    expect(titleFormatter([])).toBe('')
+    expect(titleFormatter([null, undefined, ''])).toBe('')
+  })
+})

--- a/src/transforms/__tests__/content-transforms-test.js
+++ b/src/transforms/__tests__/content-transforms-test.js
@@ -1,0 +1,143 @@
+const { runTransform, article } = require('../../../test/helpers/transform')
+
+const headingsIdTransform = require('../headings-id-transform')
+const calloutTransform = require('../callout-transform')
+const codeBreakifyTransform = require('../code-breakify-transform')
+const demoLinkTransform = require('../demo-link-transform')
+const answersLinkTransform = require('../answers-link-transform')
+const demoExternalLinkTransform = require('../demo-external-link-transform')
+
+describe('headings-id-transform', () => {
+  it('проставляет id, транслитерируя заголовок', async () => {
+    const window = await runTransform(headingsIdTransform, article('<h2>Как это работает</h2>'))
+
+    expect(window.document.querySelector('h2').getAttribute('id')).toBe('kak-eto-rabotaet')
+  })
+
+  it('разводит одинаковые заголовки постфиксами', async () => {
+    const html = article('<h2>Пример</h2><h3>Пример</h3><h4>Пример</h4>')
+    const window = await runTransform(headingsIdTransform, html)
+    const ids = Array.from(window.document.querySelectorAll('h2, h3, h4')).map((h) => h.getAttribute('id'))
+
+    expect(ids).toEqual(['primer', 'primer-1', 'primer-2'])
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('не трогает h1', async () => {
+    const window = await runTransform(headingsIdTransform, article('<h1>Заголовок статьи</h1>'))
+
+    expect(window.document.querySelector('h1').getAttribute('id')).toBeNull()
+  })
+})
+
+describe('callout-transform', () => {
+  it('превращает безымянный aside в коллаут', async () => {
+    const window = await runTransform(calloutTransform, article('<aside><p>Совет дня</p></aside>'))
+    const callout = window.document.querySelector('.callout')
+
+    expect(callout).not.toBeNull()
+    expect(callout.tagName.toLowerCase()).toBe('aside')
+    expect(callout.querySelector('.callout__content').textContent).toContain('Совет дня')
+  })
+
+  it('выносит ведущий эмодзи в иконку и убирает его из текста', async () => {
+    const window = await runTransform(calloutTransform, article('<aside><p>🔥 Важное</p></aside>'))
+
+    expect(window.document.querySelector('.callout__icon').textContent.trim()).toBe('🔥')
+    expect(window.document.querySelector('.callout__content').textContent).not.toContain('🔥')
+  })
+
+  it('обходится без иконки, когда эмодзи нет', async () => {
+    const window = await runTransform(calloutTransform, article('<aside><p>Просто текст</p></aside>'))
+
+    expect(window.document.querySelector('.callout__icon')).toBeNull()
+  })
+
+  it('не трогает aside с классом', async () => {
+    const window = await runTransform(calloutTransform, article('<aside class="practices"><p>Совет</p></aside>'))
+
+    expect(window.document.querySelector('.callout')).toBeNull()
+  })
+})
+
+describe('code-breakify-transform', () => {
+  it('расставляет переносы по спецсимволам', async () => {
+    const window = await runTransform(codeBreakifyTransform, '<code class="code-fix">border-radius</code>')
+
+    expect(window.document.querySelector('.code-fix').innerHTML).toContain('<wbr>')
+  })
+
+  it('не ставит перенос перед первым спецсимволом слова', async () => {
+    const window = await runTransform(codeBreakifyTransform, '<code class="code-fix">-webkit-box</code>')
+
+    expect(window.document.querySelector('.code-fix').innerHTML.startsWith('<wbr>')).toBe(false)
+  })
+
+  it('не трогает код без класса code-fix', async () => {
+    const window = await runTransform(codeBreakifyTransform, '<code>border-radius</code>')
+
+    expect(window.document.querySelector('code').innerHTML).toBe('border-radius')
+  })
+})
+
+describe('demo-link-transform', () => {
+  it('чинит относительный путь в разделе «На практике»', async () => {
+    const html = '<div id="practices"><iframe src="../demos/index.html"></iframe></div>'
+    const window = await runTransform(demoLinkTransform, html)
+
+    expect(window.document.querySelector('iframe').getAttribute('src')).toBe('./demos/index.html')
+  })
+
+  it('чинит пути и у картинок', async () => {
+    const window = await runTransform(demoLinkTransform, '<div id="practices"><img src="../images/a.png"></div>')
+
+    expect(window.document.querySelector('img').getAttribute('src')).toBe('./images/a.png')
+  })
+
+  it('не трогает медиа за пределами раздела', async () => {
+    const window = await runTransform(demoLinkTransform, '<img src="../images/a.png">')
+
+    expect(window.document.querySelector('img').getAttribute('src')).toBe('../images/a.png')
+  })
+})
+
+describe('answers-link-transform', () => {
+  it('разворачивает путь до картинки ответа в абсолютный', async () => {
+    const html = `
+      <div id="questions">
+        <div class="question__answer" id="css-answers-solarrust">
+          <img src="picture.png">
+        </div>
+      </div>
+    `
+    const window = await runTransform(answersLinkTransform, html)
+
+    expect(window.document.querySelector('img').getAttribute('src')).toBe(
+      '/interviews/css/answers/solarrust/picture.png',
+    )
+  })
+})
+
+describe('demo-external-link-transform', () => {
+  it('оборачивает демку в figure со ссылкой на отдельную вкладку', async () => {
+    const html = article('<iframe src="./demos/index.html"></iframe>')
+    const window = await runTransform(demoExternalLinkTransform, html, {
+      outputPath: 'dist/css/display/index.html',
+    })
+    const link = window.document.querySelector('.figure__caption a')
+
+    expect(window.document.querySelector('figure.figure')).not.toBeNull()
+    expect(link.getAttribute('href')).toBe('/css/display/demos/index.html')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+  })
+
+  it('не трогает встроенные видео и прочие iframe', async () => {
+    const html = article('<iframe src="https://www.youtube.com/embed/xyz"></iframe>')
+    const window = await runTransform(demoExternalLinkTransform, html, {
+      outputPath: 'dist/css/display/index.html',
+    })
+
+    expect(window.document.querySelector('figure.figure')).toBeNull()
+  })
+})

--- a/src/transforms/__tests__/markup-transforms-test.js
+++ b/src/transforms/__tests__/markup-transforms-test.js
@@ -1,0 +1,123 @@
+const { runTransform, article } = require('../../../test/helpers/transform')
+
+const linkTransform = require('../link-transform')
+const tableTransform = require('../table-transform')
+const detailsTransform = require('../details-transform')
+const iframeAttrTransform = require('../iframe-attr-transform')
+const articleInlineCodeTransform = require('../article-inline-code-transform')
+const codeClassesTransform = require('../code-classes-transform')
+
+describe('link-transform', () => {
+  it('проставляет класс ссылкам внутри контента', async () => {
+    const window = await runTransform(linkTransform, article('<p><a href="/css/">Раздел</a></p>'))
+    const link = window.document.querySelector('a')
+
+    expect(link.classList.contains('link')).toBe(true)
+  })
+
+  it('не трогает ссылки за пределами контента', async () => {
+    const window = await runTransform(linkTransform, `<nav><a href="/">Главная</a></nav>${article('')}`)
+    const link = window.document.querySelector('nav a')
+
+    expect(link.classList.contains('link')).toBe(false)
+  })
+
+  it('не падает на странице без контента', async () => {
+    await expect(runTransform(linkTransform, '<p>Просто страница</p>')).resolves.toBeDefined()
+  })
+})
+
+describe('table-transform', () => {
+  it('оборачивает таблицу в прокручиваемый контейнер', async () => {
+    const window = await runTransform(tableTransform, article('<table><tr><td>Ячейка</td></tr></table>'))
+    const wrapper = window.document.querySelector('.table-wrapper')
+
+    expect(wrapper).not.toBeNull()
+    expect(wrapper.getAttribute('tabindex')).toBe('0')
+    expect(wrapper.querySelector('table')).not.toBeNull()
+  })
+
+  it('сохраняет содержимое таблицы', async () => {
+    const window = await runTransform(tableTransform, article('<table><tr><td>Ячейка</td></tr></table>'))
+
+    expect(window.document.querySelector('.table-wrapper table td').textContent).toBe('Ячейка')
+  })
+
+  it('оборачивает каждую таблицу отдельно', async () => {
+    const html = article('<table><tr><td>1</td></tr></table><table><tr><td>2</td></tr></table>')
+    const window = await runTransform(tableTransform, html)
+
+    expect(window.document.querySelectorAll('.table-wrapper')).toHaveLength(2)
+  })
+})
+
+describe('details-transform', () => {
+  it('размечает details и оборачивает содержимое', async () => {
+    const html = article('<details><summary>Заголовок</summary><p>Текст</p></details>')
+    const window = await runTransform(detailsTransform, html)
+    const details = window.document.querySelector('details')
+
+    expect(details.classList.contains('details')).toBe(true)
+    expect(details.querySelector('summary').classList.contains('details__summary')).toBe(true)
+    expect(details.querySelector('.details__content.content')).not.toBeNull()
+  })
+
+  it('кладёт содержимое внутрь обёртки, а не рядом', async () => {
+    const html = article('<details><summary>Заголовок</summary><p>Текст</p></details>')
+    const window = await runTransform(detailsTransform, html)
+
+    expect(window.document.querySelector('.details__content').textContent).toContain('Текст')
+  })
+})
+
+describe('iframe-attr-transform', () => {
+  it('добавляет ленивую загрузку', async () => {
+    const window = await runTransform(iframeAttrTransform, article('<iframe src="/demo/"></iframe>'))
+
+    expect(window.document.querySelector('iframe').getAttribute('loading')).toBe('lazy')
+  })
+
+  it('не перезаписывает уже заданное значение', async () => {
+    const html = article('<iframe src="/demo/" loading="eager"></iframe>')
+    const window = await runTransform(iframeAttrTransform, html)
+
+    expect(window.document.querySelector('iframe').getAttribute('loading')).toBe('eager')
+  })
+})
+
+describe('article-inline-code-transform', () => {
+  it('размечает инлайновый код в абзацах и списках', async () => {
+    const html = article('<p><code>display</code></p><ul><li><code>flex</code></li></ul>')
+    const window = await runTransform(articleInlineCodeTransform, html)
+
+    for (const code of window.document.querySelectorAll('code')) {
+      expect(code.classList.contains('inline-code')).toBe(true)
+      expect(code.classList.contains('font-theme--code')).toBe(true)
+    }
+  })
+
+  it('не трогает код в блоках pre', async () => {
+    const window = await runTransform(articleInlineCodeTransform, article('<pre><code>const a = 1</code></pre>'))
+
+    expect(window.document.querySelector('pre code').classList.contains('inline-code')).toBe(false)
+  })
+})
+
+describe('code-classes-transform', () => {
+  it('размечает код внутри заголовка статьи', async () => {
+    const window = await runTransform(codeClassesTransform, '<h1 class="article__title"><code>display</code></h1>')
+    const code = window.document.querySelector('code')
+
+    expect(code.classList.contains('article__title-code')).toBe(true)
+    expect(code.classList.contains('code-fix')).toBe(true)
+  })
+
+  it('использует свой класс для каждого вида родителя', async () => {
+    const html = '<a class="articles-group__link"><code>a</code></a><p class="figure__caption"><code>b</code></p>'
+    const window = await runTransform(codeClassesTransform, html)
+    const [groupCode, captionCode] = window.document.querySelectorAll('code')
+
+    expect(groupCode.classList.contains('articles-group__code')).toBe(true)
+    expect(captionCode.classList.contains('figure__caption-code')).toBe(true)
+  })
+})

--- a/test/helpers/transform.js
+++ b/test/helpers/transform.js
@@ -1,0 +1,46 @@
+// Помощник для тестов трансформаций.
+//
+// Трансформации не умеют работать с голым фрагментом разметки: они ищут
+// контейнер вроде `.content` или `.article__content-inner` и правят DOM внутри
+// него. Поэтому helper собирает документ так же, как это делает .eleventy.js —
+// через linkedom, — и передаёт трансформации ровно те три аргумента, которые
+// она получает в сборке.
+
+'use strict'
+
+const { parseHTML } = require('linkedom')
+
+const DEFAULT_OUTPUT_PATH = 'dist/css/example/index.html'
+
+/**
+ * Прогоняет трансформацию через документ, собранный вокруг разметки.
+ *
+ * @param {Function} transform трансформация из src/transforms
+ * @param {string} html разметка, которая попадёт внутрь body
+ * @param {object} [options]
+ * @param {string} [options.outputPath] путь к странице, как его видит сборка
+ * @returns {Promise<Window>} окно после применения трансформации
+ */
+async function runTransform(transform, html, options = {}) {
+  const { outputPath = DEFAULT_OUTPUT_PATH } = options
+  const content = `<!DOCTYPE html><html lang="ru"><head><title>Тест</title></head><body>${html}</body></html>`
+  const window = parseHTML(content)
+
+  await transform(window, content, outputPath)
+
+  return window
+}
+
+/**
+ * Разметка статьи: трансформации ищут именно эти контейнеры.
+ * `.content` лежит внутри `.article__content-inner` — так же, как в шаблоне.
+ */
+function article(inner) {
+  return `
+    <div class="article__content-inner">
+      <div class="article__content content">${inner}</div>
+    </div>
+  `
+}
+
+module.exports = { runTransform, article, DEFAULT_OUTPUT_PATH }


### PR DESCRIPTION
## Тесты

Было **16 тестов в 5 сьютах**, стало **71 в 12**. Раньше проверялись утилиты вроде `debounce` и обрезки текста в оглавлении, а всё, что формирует разметку статей, не проверялось ничем.

**Трансформации.** Их двадцать, и именно они определяют итоговый HTML: оглавление, якоря заголовков, блоки кода, коллауты, таблицы, ссылки на демки. Тесты прогоняют трансформацию через документ, собранный тем же `linkedom`, что и в сборке, и передают ровно те три аргумента, которые она получает в `.eleventy.js`. Помощник для этого — `test/helpers/transform.js`.

Покрыты: `link`, `table`, `details`, `iframe-attr`, `article-inline-code`, `code-classes`, `headings-id`, `callout`, `code-breakify`, `demo-link`, `answers-link`, `demo-external-link`.

**Библиотеки сборки:** `title-formatter`, `heading-hierarchy` (построение и отрисовка оглавления, включая экранирование разметки в заголовках), `role-constructor`, `github-contribution-stats`.

Статистика участников читает `.issues.json` на верхнем уровне, а файла в репозитории нет — его готовит `doka-guide/cache`. Тест подменяет его виртуальным модулем и не зависит ни от наличия файла, ни от содержимого.

**Тесты проверены на живучесть.** Специально сломала две трансформации — убрала `tabindex` у обёртки таблиц и поменяла разделитель постфикса у одинаковых заголовков. Получила ровно два падения, после отката снова зелено. Проверки не пустые.

## Почему это важно именно сейчас

При обновлении мажоров в #1364 три gulp-плагина сломались тремя разными способами — переименованный экспорт, функция в `.default`, новые обязательные параметры. Ни одну не поймали ни тесты, ни линтеры: до gulp сборка доезжала с зелёными проверками. Трансформации сейчас в том же положении, только их двадцать, и ломаются они тише — не падением, а изменившейся разметкой.

## Воркфлоу и бэдж

Тесты добавили в CI в #1365 шагом внутри `Linting` — у них не было ни своего имени в списке проверок, ни бэджа. Теперь это **отдельный воркфлоу `Tests`**, на пулреквестах и на пуше в `main`.

**Бэдж W3C Validator в README не отображался**: он вёл на воркфлоу, удалённый в #1362. Валидация с тех пор живёт джобой внутри `Product Deploy`, чей бэдж уже есть, — поэтому мёртвый бэдж заменён на статус тестов.

## Заодно починен случайный отказ линтера

Шагу проверки editorconfig передаётся автоматический токен. `editorconfig-checker` скачивает свой бинарник через GitHub API; без токена запрос неавторизованный, а лимит общий на IP раннера. Из-за этого прогоны падали случайно, с `API rate limit exceeded` вместо ошибок разметки — так упал первый прогон #1367.

## Техническая деталь

В `jest.config.js` добавлен `transformIgnorePatterns`: `linkedom` и его зависимости (`css-select`, `dom-serializer`, `domutils` и далее) поставляются как ESM, а jest грузит `node_modules` как CommonJS и падает на `import`.

## Как проверено

- `npm test` — 71 тест, 12 сьютов
- `eslint`, `stylelint`, `editorconfig-checker`, `prettier --check` — чисто