### PR TITLE
Отключает csso на дев-сервере

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,7 +32,6 @@ const eleventyVitePlugin = require('@11ty/eleventy-plugin-vite').default
 const postcssImport = require('postcss-import')
 const postcssMediaMinmax = require('postcss-media-minmax')
 const autoprefixer = require('autoprefixer')
-const postcssCsso = require('postcss-csso')
 
 function getAllDocs(collectionAPI) {
   const dokas = collectionAPI.getFilteredByTag('doka')
@@ -470,14 +469,13 @@ module.exports = function (config) {
 
         css: {
           postcss: {
-            plugins: [
-              postcssImport,
-              postcssMediaMinmax,
-              autoprefixer,
-              postcssCsso({
-                restructure: false,
-              }),
-            ],
+            // csso здесь не нужен: на дев-сервере минификация не даёт ничего,
+            // зато ломает сборку. Он тянет css-tree 2.2.1, который не знает
+            // @container, @scope, вложенные слои и вложенность — а Vite гонит
+            // через эту цепочку и инлайновые стили демок, поэтому демка с
+            // @container отдавалась с 500. В прод-сборке csso остаётся: там
+            // postcss ходит только по src/styles, демки уезжают копией.
+            plugins: [postcssImport, postcssMediaMinmax, autoprefixer],
           },
         },
 


### PR DESCRIPTION
## Что случилось

Локально дев-сервер отдавал 500 на демках к статьям про современный CSS — `@container`, `@scope`, вложенные слои, CSS-вложенность:

```
[vite] Internal server error: [postcss] postcss-csso: index.html?html-proxy&index=0.css:56:15: ")" is expected
  56 |      @container (max-width: 420px) {
     |                ^
```

Виноват не postcss — он свежий, 8.5.26. Виноват `postcss-csso`: он тянет `csso@5.0.5`, а тот жёстко пинит `css-tree@2.2.1`. Этот парсер не знает современного синтаксиса:

```
css-tree 2.2.1  @container: падает | @scope: падает | @layer a.b: падает | вложенность &: падает
css-tree 3.2.1  @container: ок     | @scope: ок     | @layer a.b: ок     | вложенность &: ок
```

Обновиться нельзя: `postcss-csso` не выходил с августа 2022, `csso` — с февраля 2023, css-tree тем временем ушёл на 3.2.1. Стоят самые новые версии, новых просто нет.

Под раздачу демки попадают потому, что Vite прогоняет через css-цепочку и инлайновые `<style>` из HTML. На проде этого нет: gulp гоняет postcss только по `src/styles/{index.css,index.sc.css,dark-theme.css}`, а демки уезжают passthrough-копией — поэтому doka.guide/css/container/ работает, а локальная копия нет. Заодно `html-min` в прод-ветке демки и так исключает (`notDemo`, `minifyCss: false`), так что минификация демок нигде и не задумывалась.

## Что сделано

`postcssCsso` убран из vite-конфига. На дев-сервере минификация не даёт ничего — она там только ломает. В прод-сборке (`gulpfile.js`) csso остаётся нетронутым.

## Чем проверяла

Юнит-тест сюда не ложится: это конфиг плагина Vite, а ломается всё на стыке Vite + postcss. Поэтому проверяла запуском.

До правки поднимала настоящий Vite с цепочкой из `.eleventy.js` на `css/container/demos/basic/index.html` — 500 и ошибка выше. После правки гоняла полный `npm start` и ходила по страницам:

| Страница | Было | Стало |
|---|---|---|
| `/css/container/demos/basic/` | 500 | 200 |
| `/css/scope/demos/basic/` | 500 | 200 |
| `/css/layer/demos/list-of-child-layers/` | 500 | 200 |
| `/js/number-is-nan/demos/index/` | 500 | 200 |
| `/css/container/` | 200 | 200 |

`@container` и `@scope` доезжают до браузера как есть, в логе дев-сервера ни одной ошибки postcss, `/styles/index.css` и `/styles/dark-theme.css` по-прежнему 200. `npm run check` зелёный целиком.

## Что осталось за скобками

csso мёртв, и он же стоит в проде. Как только в `src/styles` появится `@container`, `@scope` или вложенность — упадёт уже боевая сборка (`@property` там уже есть, но его css-tree 2.2.1 переваривает). Замена на живой минификатор — отдельная задача, не сюда.

Ещё 15 демок падали по другой причине — опечатка `;;` в контенте, она чинится в doka-guide/content#6134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- doka-preview-1376 -->
<a href="https://platform-1376.dev.doka.guide">Превью контента</a> из ae9714c0ded4a353c080231ffe3e9b650d657977 опубликовано.
<!-- /doka-preview-1376 -->